### PR TITLE
example tests

### DIFF
--- a/webapi_tests/run.sh
+++ b/webapi_tests/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+echo "Setting up virtualenv"
+
+function notify_sudo {
+  if [ "$SUDO_NOTIFY" = "1" ]; then
+    return
+  fi
+  echo "This script requires sudo access to install pip and/or virtualenv "
+  echo "on your system.  Please enter your sudo password if prompted. "
+  echo "If you don't have sudo access, you will need a system administrator "
+  echo "to install pip and virtualenv for you."
+  SUDO_NOTIFY=1
+}
+
+which pip
+if [ $? != 0 ]; then
+  which easy_install
+  if [ $? != 0 ]; then
+    echo "Neither pip nor easy_install is found in your path"
+    echo "Please install pip directly using: http://pip.readthedocs.org/en/latest/installing.html#install-or-upgrade-pip"
+    exit 1
+  fi
+  notify_sudo
+  sudo easy_install pip || { echo 'error installing pip' ; exit 1; }
+fi
+
+which virtualenv
+if [ $? != 0 ]; then
+  notify_sudo
+  sudo pip install virtualenv || { echo 'error installing virtualenv' ; exit 1; }
+fi
+
+if [ ! -d "webapi_venv" ]; then
+  virtualenv --no-site-packages webapi_venv || { echo 'error creating virtualenv' ; exit 1; }
+fi
+
+source webapi_venv/bin/activate
+python setup.py install
+adb forward tcp:2828 tcp:2828
+echo "Done, running the suite"
+marionette --address=localhost:2828 webapi_tests/manifest.ini
+deactivate

--- a/webapi_tests/setup.py
+++ b/webapi_tests/setup.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from setuptools import setup
+
+PACKAGE_VERSION = '0.1'
+deps = ['marionette_client==0.7.1']
+        
+
+setup(name='webapi_tests',
+      version=PACKAGE_VERSION,
+      description="Minimal tests for certification",
+      classifiers=[],
+      keywords='mozilla',
+      author='Mozilla Automation and Testing Team',
+      author_email='tools@lists.mozilla.org',
+      url='https://github.com/mozilla-b2g/fxos-certsuite',
+      license='MPL',
+      packages=['webapi_tests'],
+      include_package_data=True,
+      zip_safe=False,
+      install_requires=deps,
+      entry_points="""
+      """)

--- a/webapi_tests/webapi_tests/__init__.py
+++ b/webapi_tests/webapi_tests/__init__.py
@@ -1,0 +1,1 @@
+from testcase import MinimalTestCase

--- a/webapi_tests/webapi_tests/manifest.ini
+++ b/webapi_tests/webapi_tests/manifest.ini
@@ -1,0 +1,6 @@
+[DEFAULT]
+b2g = true
+browser = true
+
+[test_orientation.py]
+[test_proximity.py]

--- a/webapi_tests/webapi_tests/test_orientation.py
+++ b/webapi_tests/webapi_tests/test_orientation.py
@@ -1,0 +1,10 @@
+from webapi_tests import MinimalTestCase
+
+class TestProximity(MinimalTestCase):
+    def test_proximity_change(self):
+        self.instruct("Ensure the phone is unlocked and in portrait mode")
+        orientation = self.marionette.execute_script("return window.wrappedJSObject.screen.mozOrientation;")
+        self.assertTrue("portrait" in orientation)
+        self.instruct("Now rotate the phone into landscape mode")
+        orientation = self.marionette.execute_script("return window.wrappedJSObject.screen.mozOrientation;")
+        self.assertTrue("landscape" in orientation)

--- a/webapi_tests/webapi_tests/test_proximity.py
+++ b/webapi_tests/webapi_tests/test_proximity.py
@@ -1,0 +1,29 @@
+from webapi_tests import MinimalTestCase
+
+class TestProximity(MinimalTestCase):
+    def tearDown(self):
+        self.marionette.execute_script("""
+        window.removeEventListener('userproximity', window.wrappedJSObject.prox_function);
+        window.removeEventListener('deviceproximity', window.wrappedJSObject.prox_function);
+        """)
+        MinimalTestCase.tearDown(self)
+    def test_proximity_change(self):
+        self.instruct("Ensure the phone is unlocked and held in your hand, perpendicular to the floor")
+        # set up listener to store changes in an object
+        # NOTE: use wrappedJSObject to access non-standard properties of window
+        script = """
+        window.wrappedJSObject.proximityStates = [];
+        window.wrappedJSObject.prox_function = function(event){
+                                  console.log("proximity event" + event);
+                                  window.wrappedJSObject.proximityStates.push(event.toString());
+                                };
+        window.addEventListener('userproximity', window.wrappedJSObject.prox_function);
+        window.addEventListener('deviceproximity', window.wrappedJSObject.prox_function);
+        """
+        self.marionette.execute_script(script)
+        self.instruct("Move your hand in front of the phone and hit OK when the screen darkens")
+        proximity_values = self.marionette.execute_script("return window.wrappedJSObject.proximityStates")
+        print proximity_values
+        # TODO: proximity events don't seem to be firing... but if you replace it with 'touchstart'
+        # and touch the screen instead of moving your hand, you'll see that the logic works
+        self.assertNotEqual(0, len(proximity_values))

--- a/webapi_tests/webapi_tests/testcase.py
+++ b/webapi_tests/webapi_tests/testcase.py
@@ -1,0 +1,16 @@
+from marionette import MarionetteTestCase
+
+class MinimalTestCase(MarionetteTestCase):
+    def __init__(self, *args, **kwargs):
+        super(MinimalTestCase, self).__init__(*args, **kwargs)
+
+    def instruct(self, message):
+        response = None
+        try:
+            response = raw_input("\n=== INSTRUCTION ===\n%s\nWere you successful? [y/n]\n" % message)
+            while response not in ['y', 'n']:
+                response = raw_input("Please enter 'y' or 'n': " % message)
+        except KeyboardInterrupt:
+            self.fail("Test interrupted by user")
+        if response == 'n':
+            self.fail("Failed on step: %s" % message)


### PR DESCRIPTION
To run the tests you can do:

`source run.sh`

which will set up a virtualenv for you and execute the tests in the webapi_tests/manifest.ini. After running run.sh, you'll have a "webapi_venv" virtual environment you can use.

Alternatively, you can set up your own virtual environment and run 'python setup.py develop' in the webapi_tests folder, so all tests will have access to the MinimalTestCase object through the webapi_tests module.

There are two example tests, test_orientation.py which is very simple since we have an API call to get data, and test_proximity.py which sets up an event listener since some webapis don't have an API for information retrieval.

So the test case example is the test_proximity.py file. The test case will run but unfortunately won't pass since the event listener for 'userproximity'/'deviceproximity' doesn't seem to be picking up the events, either due to my build or some other reason (I've run this code outside of this test, directly against the device in a system app and I still don't get the events...), but if you change that event to something that does fire, like 'touchstart' or whatever, you'll see that the the test will pass.

In any case, the test flow will work as expected and you can use this to write tests.
