### PR TITLE
Make "yes" default answer on instruction

### DIFF
--- a/webapi_tests/webapi_tests/testcase.py
+++ b/webapi_tests/webapi_tests/testcase.py
@@ -62,11 +62,11 @@ class MinimalTestCase(MarionetteTestCase):
 
     def instruct(self, message):
         response = None
+        print("\n=== INSTRUCTION ===\n%s" % message)
         try:
-            response = raw_input("\n=== INSTRUCTION ===\n%s\nWere you successful? [y/n]\n" % message)
-            while response not in ['y', 'n']:
-                response = raw_input("Please enter 'y' or 'n': ")
-        except KeyboardInterrupt:
+            while response not in ["y", "n", ""]:
+                response = raw_input("Were you successful? [Yn] ").lower()
+        except (KeyboardInterrupt, EOFError):
             self.fail("Test interrupted by user")
-        if response == 'n':
+        if response == "n":
             self.fail("Failed on step: %s" % message)


### PR DESCRIPTION
This patch changes testcase.MinimalTestcase.instruct's behaviour to the
following:
- Input is lower cased, meaning there is no difference between "Y",
  "y", "N", or "n".
- Default answer is considered to be yes, e.g. pressing the Enter key.

It also reduces some code duplication by reusing the same raw_input()
call since it's already in a while loop with the `response` variable
defined in the outer variable scope.
