### PR TITLE
add ability to unplug phone during a test, and add preliminary battery test

### DIFF
--- a/webapi_tests/webapi_tests/manifest.ini
+++ b/webapi_tests/webapi_tests/manifest.ini
@@ -4,3 +4,4 @@ browser = true
 
 [test_orientation.py]
 [test_proximity.py]
+[test_battery.py]

--- a/webapi_tests/webapi_tests/test_battery.py
+++ b/webapi_tests/webapi_tests/test_battery.py
@@ -1,0 +1,25 @@
+from webapi_tests import MinimalTestCase
+
+class TestBattery(MinimalTestCase):
+    def tearDown(self):
+        self.marionette.execute_script("""
+        window.navigator.battery.onchargingchange = null;
+        window.navigator.battery.onlevelchange = null;
+        """)
+        MinimalTestCase.tearDown(self)
+
+    def test_proximity_change(self):
+        # set up listener to store changes in an object
+        # NOTE: use wrappedJSObject to access non-standard properties of window
+        script = """
+        window.wrappedJSObject.chargeStates = [];
+        window.wrappedJSObject.charge_function = function(event){
+                                  window.wrappedJSObject.chargeStates.push(event.type);
+                                };
+        window.navigator.battery.onchargingchange = window.wrappedJSObject.charge_function;
+        """
+        self.marionette.execute_script(script)
+        self.unplug_and_instruct("Wait 5 seconds")
+        charge_values = self.marionette.execute_script("return window.wrappedJSObject.chargeStates")
+        self.assertNotEqual(0, len(charge_values))
+        self.assertEqual(charge_values[0], "chargingchange")

--- a/webapi_tests/webapi_tests/testcase.py
+++ b/webapi_tests/webapi_tests/testcase.py
@@ -91,3 +91,12 @@ class MinimalTestCase(MarionetteTestCase):
             self.fail("Test interrupted by user")
         if response == "n":
             self.fail("Failed on step: %s" % message)
+
+    def unplug_and_instruct(self, message):
+        self.instruct("Unplug the phone.\n%s\nPlug the phone back in after you are done, "\
+                      "and unlock the screen if necessary.\n" % message)
+        dm = mozdevice.DeviceManagerADB()
+        dm.forward("tcp:2828", "tcp:2828")
+        self.marionette = Marionette()
+        self.marionette.start_session()
+        self.use_cert_app()


### PR DESCRIPTION
This lets you unplug the phone, and when the user plugs it back in, it sets up the marionette client for you again.
