### PR TITLE
Prevent weakreference calls from failing

### DIFF
--- a/webapi_tests/webapi_tests/testcase.py
+++ b/webapi_tests/webapi_tests/testcase.py
@@ -6,7 +6,9 @@ from marionette import Marionette, MarionetteTestCase, MarionetteException
 class MinimalTestCase(MarionetteTestCase):
     def __init__(self, *args, **kwargs):
         self.cert_test_app = None
-        super(MinimalTestCase, self).__init__(*args, **kwargs)
+        # Use a new marionette object instead of relying on older references
+        self.marionette = Marionette
+        super(MinimalTestCase, self).__init__(self.marionette, **kwargs)
 
     def setUp(self):
         super(MinimalTestCase, self).setUp()


### PR DESCRIPTION
Long story short: weakreferences to the Marionette object were being shared across TestCases. We don't benefit from this behaviour, and it was actually causing us to fail if we have to create a new Marionette object (which is the case when we physically disconnect the phone like in test_battery.py). If you disconnect, the next TestCase will fail since it's trying to use an older Marionette object that no longer has a connection, and you get Broken Pipe issues. This is a Marionette bug (we shoud be able to resuse the Marionette object if we disconnect), but we don't have time to fix it this week.

This PR makes us use a new Marionette object per TestCase, so we don't share these objects and we don't run into this failure.
