### PR TITLE
wait for the testapp to load

### DIFF
--- a/webapi_tests/webapi_tests/testcase.py
+++ b/webapi_tests/webapi_tests/testcase.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import mozdevice
 from marionette import Marionette, MarionetteTestCase, MarionetteException
@@ -43,6 +44,14 @@ class MinimalTestCase(MarionetteTestCase):
         except Exception as e:
             message = "Unexpected exception: %s" % e
             self.fail(message)
+        tries = 60 
+        while tries > 0:
+            if 'blank' not in self.marionette.get_url():
+                break
+            time.sleep(1)
+            tries -= 1
+        if tries == 0:
+            self.fail("CertTest app did not load in time")
         self.assertTrue("certtest" in self.marionette.get_url())
 
     def manually_close_app(self):


### PR DESCRIPTION
Sometimes the app takes long to load after launching, so 
         self.assertTrue("certtest" in self.marionette.get_url())

would fail since the current url would be about:blank since the page was still loading. I've added some wait code. Unfortunately, we can't use the Wait class since we're stuck with marionette_client 0.7.1 :(
