### PR TITLE
Upgrade marionette dependency to above 0.7.1.1

### DIFF
--- a/webapi_tests/setup.py
+++ b/webapi_tests/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 PACKAGE_VERSION = '0.1'
-deps = ['marionette_client==0.7.1',
+deps = ['marionette_client>=0.7.1.1',
         'marionette_extension >= 0.1',
         'moznetwork>=0.24',
         'tornado>=3.2',


### PR DESCRIPTION
This contains the wait module which is needed by some tests.
