### PR TITLE
Convert mdas and ato's tests to the semiauto framework

### DIFF
--- a/webapi_tests/orientation/__init__.py
+++ b/webapi_tests/orientation/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapi_tests/orientation/test_device_orientation.py
+++ b/webapi_tests/orientation/test_device_orientation.py
@@ -1,0 +1,67 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from semiauto import TestCase
+
+
+class TestDeviceOrientation(TestCase):
+    def tearDown(self):
+        clear_script = """
+            window.removeEventListener("deviceorientation", window.wrappedJSObject.deviceListener);
+            window.removeEventListener("deviceorientation", window.wrappedJSObject.checkValues);
+        """
+        self.marionette.execute_script(clear_script)
+        TestCase.tearDown(self)
+
+    def get_window_value(self, name):
+        return self.marionette.execute_script("return window.wrappedJSObject.%s;" % name)
+
+    def test_device_changes(self):
+        # set up listener to store changes in an object
+        script = """
+        window.wrappedJSObject.absolute = null;
+        window.wrappedJSObject.alphaOrig = null;
+        window.wrappedJSObject.betaOrig = null;
+        window.wrappedJSObject.gammaOrig = null; 
+        window.wrappedJSObject.alpha = false;
+        window.wrappedJSObject.beta = false;
+        window.wrappedJSObject.gamma = false;
+        window.wrappedJSObject.checkValues = function(evt) {
+            var setDeviceValue = function(value){
+              if (!window.wrappedJSObject[value]) {
+                console.log("MDAS: FFFS ORIG" + window.wrappedJSObject[value+'Orig']);
+                console.log("MDAS: FFFS goddamn new" + evt[value]);
+                var orig = Math.abs(window.wrappedJSObject[value+'Orig']);
+                var newValue = Math.abs(evt[value]);
+                console.log("MDAS " + value + " : " + (newValue - orig));
+                window.wrappedJSObject[value] = ((Math.abs(newValue-orig) > 70) ? true : false);
+              }
+            };
+            setDeviceValue('alpha');
+            setDeviceValue('beta');
+            setDeviceValue('gamma');
+        };
+        window.wrappedJSObject.deviceListener = function (evt) {
+            window.wrappedJSObject.removeEventListener("deviceorientation", window.wrappedJSObject.deviceListener);
+            window.wrappedJSObject.absolute = evt.absolute;
+            window.wrappedJSObject.alphaOrig = evt.alpha;
+            window.wrappedJSObject.betaOrig = evt.beta;
+            window.wrappedJSObject.gammaOrig = evt.gamma;
+            console.log("NOOOOOOOOOOOOOO");
+            window.wrappedJSObject.addEventListener("deviceorientation", window.wrappedJSObject.checkValues);
+        };
+        window.wrappedJSObject.addEventListener("deviceorientation", window.wrappedJSObject.deviceListener);
+        """
+        self.instruct("Place the phone on a level surface and make sure the lockscreen is not on")
+        # set up listener to store changes in an object
+        self.marionette.execute_script(script)
+        self.instruct("Keep the phone on the surface and rotate the phone by more than 90 degrees "\
+                      "then back to its starting position (z-axis test)")
+        self.instruct("Pick up the phone and rotate the phone so the screen is perpendicular to the table, "\
+                      "so the screen is facing you, then hold it parallel to the floor (y-axis test)")
+        self.instruct("Rotate the phone left or right by more than 90 degrees and back to its starting position (x-axis test)")
+        self.assertEqual(type(self.get_window_value("absolute")), bool, "expected absolute")
+        self.assertTrue(self.get_window_value('alpha'), "expected alpha")
+        self.assertTrue(self.get_window_value('beta'), "expected beta")
+        self.assertTrue(self.get_window_value('gamma'), "expected gamma")

--- a/webapi_tests/orientation/test_screen_orientation.py
+++ b/webapi_tests/orientation/test_screen_orientation.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from semiauto import TestCase
+
+
+class TestScreenOrientation(TestCase):
+    def check_orientation(self, mode):
+        orientation = self.marionette.execute_script("return window.wrappedJSObject.screen.mozOrientation;")
+        self.assertTrue(mode in orientation, "the screen.mozOrientation value is incorrect/not what was expected")
+
+    def test_orientation_change(self):
+        self.instruct("Ensure the phone is unlocked and in portrait mode")
+        self.check_orientation("portrait")
+        self.instruct("Now rotate the phone into landscape position and wait for the screen to adjust to landscape mode \
+                      (watch the notifications ribbon at the top).")
+        self.check_orientation("landscape")
+
+    def test_orientation_lock(self):
+        self.instruct("Ensure the phone is unlocked and in portrait mode")
+        self.check_orientation("portrait")
+        self.marionette.execute_script("return window.wrappedJSObject.screen.mozLockOrientation('portrait');")
+        self.instruct("Now rotate the phone into landscape position. The screen should NOT adjust to the new orientation.")
+        self.check_orientation("portrait")
+        self.marionette.execute_script("return window.wrappedJSObject.screen.mozUnlockOrientation();")
+        self.instruct("Now rotate the phone into portrait position, then back to landscape position. " \
+                      "The screen should adjust to the new orientation. You may need to wait a few seconds.")
+        self.check_orientation("landscape")
+        self.marionette.execute_script("return window.wrappedJSObject.screen.mozLockOrientation('landscape');")
+        self.instruct("Now rotate the phone into portrait mode. The screen should NOT adjust to the new orientation.")
+        self.check_orientation("landscape")
+        self.marionette.execute_script("return window.wrappedJSObject.screen.mozUnlockOrientation();")
+        self.instruct("Now rotate the phone into landscape position, then back to portrait position. " \
+                      "The screen should adjust to the new orientation. You may need to wait a few seconds.")
+        self.check_orientation("portrait")

--- a/webapi_tests/proximity/__init__.py
+++ b/webapi_tests/proximity/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapi_tests/proximity/test_proximity.py
+++ b/webapi_tests/proximity/test_proximity.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from semiauto import TestCase
+
+
+class TestProximity(TestCase):
+    def tearDown(self):
+        self.marionette.execute_script("""
+        window.removeEventListener('devicelight', window.wrappedJSObject.prox_function);
+        """)
+        TestCase.tearDown(self)
+
+    def test_proximity_change(self):
+        self.instruct("Ensure the phone is unlocked and held in your hand, perpendicular to the floor")
+        # set up listener to store changes in an object
+        # NOTE: use wrappedJSObject to access non-standard properties of window
+        script = """
+        window.wrappedJSObject.proximityStates = [];
+        window.wrappedJSObject.prox_function = function(event){
+                                  window.wrappedJSObject.proximityStates.push((event.value != undefined));
+                                };
+        window.addEventListener('devicelight', window.wrappedJSObject.prox_function);
+        """
+        self.marionette.execute_script(script)
+        self.instruct("Move your hand toward the screen until the screen darkens")
+        proximity_values = self.marionette.execute_script("return window.wrappedJSObject.proximityStates")
+        self.assertNotEqual(0, len(proximity_values), "Expected proximity event")
+        self.assertTrue(proximity_values[0], "Expected proximity event")

--- a/webapi_tests/tcp_socket/__init__.py
+++ b/webapi_tests/tcp_socket/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapi_tests/tcp_socket/test_tcp_socket.py
+++ b/webapi_tests/tcp_socket/test_tcp_socket.py
@@ -1,0 +1,244 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SocketServer
+import socket
+import threading
+
+import moznetwork
+
+from semiauto import TestCase
+
+
+"""Tests for the TCP Socket API available to privileged and certified
+Firefox OS apps.
+
+The TCPSocket API offers a whole API to open and use a TCP
+connection. This allows app makers to implement any protocol available
+on top of TCP such as IMAP, IRC, POP, HTTP, etc., or even build their
+own to sustain any specific needs they could have.
+
+Specification: https://developer.mozilla.org/en-US/docs/WebAPI/TCP_Socket
+
+This test case is minimal and not exhaustive!
+
+"""
+
+
+class TCPServerHandler(SocketServer.BaseRequestHandler):
+    def handle(self):
+        data = self.request.recv(1024).strip()
+        print "{} wrote:".format(self.client_address[0])
+        print data
+        self.request.sendall(data.upper())
+
+
+class TCPTestServer(object):
+    def __init__(self, addr, server_cls=None, handler_cls=None):
+        self.addr = addr
+        self.started = False
+
+        if not server_cls:
+            server_cls = SocketServer.TCPServer
+        if not handler_cls:
+            handler_cls = TCPServerHandler
+
+        self.server = server_cls(self.addr, handler_cls)
+
+    def start(self, block=False):
+        """Start the socket server.
+
+        :param block: True to run the server on the current thread,
+            blocking, False to run on a separate thread.
+
+        """
+
+        self.started = True
+
+        if block:
+            self.server.start()
+        else:
+            self.server_thread = threading.Thread(
+                target=self.server.serve_forever)
+            self.server_thread.daemon = True  # don't hang on exit
+            self.server_thread.start()
+
+    def stop(self):
+        """Stop the socket server.
+
+        If the server is not running, this method has no effect.
+
+        """
+
+        if self.started:
+            try:
+                self.server.stop()
+                self.server_thread.join()
+                self.server_thread = None
+            except AttributeError:
+                pass
+            self.started = False
+        self.server = None
+
+    def is_alive(self):
+        """Ascertains whether the socket server has been started."""
+        return self.started
+
+
+def get_free_port(device="127.0.0.1"):
+    """Retreives a free port in the ephermal range."""
+
+    port = None
+    so = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        so.bind((device, 0))
+        so.listen(3)
+        port = so.getsockname()[1]
+    finally:
+        so.close()
+    return port
+
+
+class TcpSocketTestCase(TestCase):
+    def setUp(self):
+        super(TcpSocketTestCase, self).setUp()
+        self.server = TCPTestServer((moznetwork.get_ip(), get_free_port()))
+        self.server.start()
+
+    def tearDown(self):
+        self.server.stop()
+        super(TcpSocketTestCase, self).tearDown()
+
+
+class TestTcpSocketFormality(TestCase):
+    def prop(self, pp, obj):
+        return self.marionette.execute_script("return %s.%s" % (pp, obj))
+
+    def prop_in(self, pp, obj):
+        return self.marionette.execute_script("return '%s' in %s" % (pp, obj))
+
+    def assert_property_in(self, pp, obj):
+        is_present = self.prop_in(pp, obj)
+        self.assertTrue(is_present, "%s property not found on %s" % (pp, obj))
+
+    def test_api_available(self):
+        self.assert_property_in("mozTCPSocket", "navigator")
+
+    def test_properties(self):
+        for prop in ["host", "port", "ssl", "bufferedAmount",
+                     "binaryType", "readyState"]:
+            self.assert_property_in(prop, "navigator.mozTCPSocket")
+
+        self.assertEqual(self.prop("navigator.mozTCPSocket", "host"), "", "'host' incorrect")
+        self.assertEqual(self.prop("navigator.mozTCPSocket", "port"), 0, "'port' incorrect")
+        self.assertEqual(self.prop("navigator.mozTCPSocket", "ssl"), False, "'ssl' incorrect")
+        self.assertEqual(
+            self.prop("navigator.mozTCPSocket", "readyState"), "closed", "'readyState' incorrect")
+        self.assertEqual(
+            self.prop("navigator.mozTCPSocket", "binaryType"), "string", "'binaryType' incorrect")
+
+        # The following code is preferable, but triggers a null
+        # pointer exception in the bufferedAmount property function in
+        # dom/network/TCPSocket.js.
+
+        # props = self.marionette.execute_script(
+        #     "return navigator.mozTCPSocket")
+        # self.assertIn("host", props)
+        # self.assertIn("port", props)
+        # self.assertIn("ssl", props)
+        # self.assertIn("bufferedAmount", props)
+        # self.assertIn("binaryType", props)
+        # self.assertIn("readyState", props)
+
+        # self.assertEqual(props["host"], "")
+        # self.assertEqual(props["port"], 0)
+        # self.assertEqual(props["ssl"], False)
+        # self.assertEqual(props["bufferedAmount"], 0)
+        # self.assertEqual(props["readyState"], "closed")
+        # self.assertEqual(props["binaryType"], "string")
+
+
+# class TestTcpSocketOpen(TcpSocketTestCase):
+    # def test_connect_fail(self):
+    #     pass
+
+    # def test_connect(self):
+    #     pass
+
+    # def test_connect_with_binarytype_arraybuffer(self):
+    #     self.marionette.execute_script(
+    #         "let so = navigator.mozTCPSocket.open('%s', %d, "
+    #         "{'binaryType': 'arraybuffer'})" %
+    #         (self.server.addr[0], self.server.addr[1]))
+    #     self.assertEqual(self.marionette.execute_script("return so.binaryType",
+    #                                                     "arraybuffer"))
+
+    # def test_close(self):
+    #     pass
+
+    # def test_upgrade_to_secure(self):
+    #     pass
+
+    # TODO(ato): Add SSL tests
+
+
+# class TestTcpSocketTransmit(TcpSocketTestCase):
+#     def test_send_string(self):
+#         pass
+
+#     def test_send_uint8array(self):
+#         pass
+
+#     def test_send_no_data(self):
+#         pass
+
+#     def test_send_128kb_data_returns_false(self):
+#         pass
+
+#     def test_send_128kb_data_triggers_ondrain(self):
+#         pass
+
+
+# class TestTcpSocketReceive(TcpSocketTestCase):
+#     def test_buffered_amount(self):
+#         pass
+
+#     def test_receives_string_data(self):
+#         pass
+
+#     def test_receives_arraybuffer_data(self):
+#         pass
+
+#     def test_suspend_stops_firing_ondata(self):
+#         pass
+
+#     def test_resume_starts_firing_ondata(self):
+#         pass
+
+
+# class TestTcpSocketEvents(TcpSocketTestCase):
+#     def test_onopen(self):
+#         pass
+
+#     def test_ondrain(self):
+#         pass
+
+#     def test_ondata(self):
+#         pass
+
+#     def test_onerror(self):
+#         pass
+
+#     def test_onclose(self):
+#         pass
+
+
+# class TestTcpServerSocket(TestCase):
+#     def test_listen_on_port_below_1024(self):
+#         pass
+
+#     def test_listen_on_port_above_1024(self):
+#         pass
+
+#     # TODO(ato): Tests missing here

--- a/webapi_tests/vibration/__init__.py
+++ b/webapi_tests/vibration/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webapi_tests/vibration/test_vibrate_basic.py
+++ b/webapi_tests/vibration/test_vibrate_basic.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+
+from semiauto import TestCase
+
+
+class TestVibrateBasic(TestCase):
+    def test_vibrate_basic(self):
+        self.instruct("Ensure the phone is unlocked, then hold the phone.")
+        self.marionette.execute_script("window.navigator.vibrate(200);")
+        self.confirm("Did you feel a single vibration?")
+        self.instruct("Ensure the phone is unlocked, then hold the phone.")
+        self.marionette.execute_script("window.navigator.vibrate([200]);")
+        self.confirm("Did you feel a single vibration?")
+        self.instruct("Ensure the phone is unlocked, then hold the phone.")
+        self.marionette.execute_script("window.navigator.vibrate([200, 1000, 200]);")
+        time.sleep(1)
+        self.confirm("Did you feel two vibrations, with about 1 second between each pulse?")


### PR DESCRIPTION
Convert the tests that mdas and ato made before with the 'MinimalTestCase', to use the new semiauto 'TestCase' framework. Note: Leaving the battery test out as it is failing/not ready.
