### PR TITLE
map_action no longer exists in mozlog, update code

### DIFF
--- a/certsuite/harness.py
+++ b/certsuite/harness.py
@@ -39,9 +39,8 @@ def get_test_failures(raw_log):
         if data['status'] == 'FAIL':
             failures.append(data)
     with open(raw_log, 'r') as f:
-        #XXX: bug 985606: map_action is a generator
-        list(reader.map_action(reader.read(f),
-                               {"test_status":test_status}))
+        reader.each_log(reader.read(f),
+                               {"test_status":test_status})
     return failures
 
 def run_test(test, temp_dir, args):


### PR DESCRIPTION
map_action doesn't exist anymore in the updated mozlog package, so the result generation code ended up breaking and not generating results.

This fixes the problem, and I've added a war room agenda item to focus on testing our harness so this will be caught next time it happens.
