### PR TITLE
Fix telephony tests on tarako by disabling dialer agent (Bug 997248)

### DIFF
--- a/webapi_tests/telephony/telephony_test.py
+++ b/webapi_tests/telephony/telephony_test.py
@@ -239,7 +239,8 @@ class TelephonyTestCommon(object):
         except:
             self.marionette.switch_to_frame(self.app["frame"])
             self.fail("failed to disable dialer agent")
-        self.marionette.switch_to_frame(self.app["frame"])
+        finally:
+            self.marionette.switch_to_frame(self.app["frame"])
 
     def enable_dialer(self):
         # enable system dialer agent to handle calls
@@ -253,4 +254,5 @@ class TelephonyTestCommon(object):
         except:
             self.marionette.switch_to_frame(self.app["frame"])
             self.fail("failed to disable dialer agent")
-        self.marionette.switch_to_frame(self.app["frame"])
+        finally:
+            self.marionette.switch_to_frame(self.app["frame"])

--- a/webapi_tests/telephony/test_telephony_incoming.py
+++ b/webapi_tests/telephony/test_telephony_incoming.py
@@ -9,10 +9,13 @@ from telephony import TelephonyTestCommon
 
 
 class TestTelephonyIncoming(TestCase, TelephonyTestCommon):
-    def test_telephony_incoming(self):
+    def setUp(self):
+        self.addCleanup(self.clean_up)
+        super(TestTelephonyIncoming, self).setUp()
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
 
+    def test_telephony_incoming(self):
         # ask user to call the device; answer and verify via webapi
         self.user_guided_incoming_call()
 
@@ -22,5 +25,6 @@ class TestTelephonyIncoming(TestCase, TelephonyTestCommon):
         # disconnect the call
         self.hangup_active_call()
 
+    def clean_up(self):
         # re-enable the default dialer manager
         self.enable_dialer()

--- a/webapi_tests/telephony/test_telephony_outgoing.py
+++ b/webapi_tests/telephony/test_telephony_outgoing.py
@@ -9,6 +9,12 @@ from telephony import TelephonyTestCommon
 
 
 class TestTelephonyOutgoing(TestCase, TelephonyTestCommon):
+    def setUp(self):
+        self.addCleanup(self.clean_up)
+        super(TestTelephonyOutgoing, self).setUp()
+        # disable the default dialer manager so it doesn't grab our calls
+        self.disable_dialer()
+
     def test_telephony_outgoing(self):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
@@ -22,5 +28,6 @@ class TestTelephonyOutgoing(TestCase, TelephonyTestCommon):
         # disconnect the call
         self.hangup_active_call()
 
+    def clean_up(self):
         # re-enable the default dialer manager
         self.enable_dialer()


### PR DESCRIPTION
Disable the default gaia dialer agent, so that incoming/outgoing calls are handled solely by the certest app. Previously the dialing agent was grabbing the calls, causing the device to run OOM.
