### PR TITLE
Run webapi verifier tests automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 PACKAGE_VERSION = '0.1'
-deps = ['fxos-appgen>=0.2.7',
+deps = ['fxos-appgen>=0.2.9',
         'marionette_client>=0.7.1.1',
         'marionette_extension >= 0.1',
         'mozdevice >= 0.33',


### PR DESCRIPTION
Run tests automatically by:
- Getting request headers from POST of results rather than navigating to a separate page.
- Using fxos_appgen to install hosted app instead of navigating to an install page.
- Using new fxos_appgen.launch_app to run apps automatically

I also fixed a small (but annoying) bug in reporting the results.

This can't be merged until the corresponding changes to fxos_appgen land, but just in case someone wants to get an early start on a review, here goes :)
