### PR TITLE
add ability/instructions for installing marionette extension per version

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -27,3 +27,11 @@ same Wi-Fi network.
 Furthermore, the device must have a SIM card with a functioning phone
 subscription to receive SMS messages for a subset of the tests to
 pass.
+
+Lastly, you must have Marionette installed on your phone. To install
+it, please run::
+
+    source install_marionette_extension.sh VERSION
+
+Where you must replace VERSION with the base FirefoxOS version number
+you are running against. We currently support 1.3 and 1.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 PACKAGE_VERSION = '0.1'
 deps = ['fxos-appgen>=0.2.9',
         'marionette_client>=0.7.1.1',
-        'marionette_extension >= 0.1',
+        'marionette_extension >= 0.3',
         'mozdevice >= 0.33',
         'mozlog >= 1.8',
         'moznetwork >= 0.24',

--- a/webapi_tests/install_marionette_extension.sh
+++ b/webapi_tests/install_marionette_extension.sh
@@ -5,5 +5,5 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 source setup_venv.sh
-install_marionette
+install_marionette $1
 deactivate


### PR DESCRIPTION
This is part of Bug 1016537 (https://bugzilla.mozilla.org/show_bug.cgi?id=1016537). I've updated the marionette_extension python package to deal with v1.4, and now we need to add the ability to install the right marionette version according to firefoxOS version.

This patch gives instructions on how to install the extension, and it is safe to run this modified script if you already have marionette installed. It will just say it's already installed and won't try to reinstall it.

The script requires the user to input the version number, since there isn't a known way for us to programmatically figure that out with just adb.
