### PR TITLE
move install_marionette_extension to main folder

### DIFF
--- a/install_marionette_extension.sh
+++ b/install_marionette_extension.sh
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+pushd webapi_tests
 source setup_venv.sh
-install_marionette $1
+marionette_extension --install $1
 deactivate
+popd

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 PACKAGE_VERSION = '0.1'
 deps = ['fxos-appgen>=0.2.9',
         'marionette_client>=0.7.1.1',
-        'marionette_extension >= 0.3',
+        'marionette_extension >= 0.4',
         'mozdevice >= 0.33',
         'mozlog >= 1.8',
         'moznetwork >= 0.24',

--- a/webapi_tests/setup.py
+++ b/webapi_tests/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 
 PACKAGE_VERSION = '0.1'
 deps = ['marionette_client>=0.7.1.1',
-        'marionette_extension >= 0.1',
+        'marionette_extension >= 0.4',
         'mozlog>=1.7',
         'moznetwork>=0.24',
         'moztest>=0.5',


### PR DESCRIPTION
Since install_marionette_extension.sh has to be used to run the automated tests and not just the semiauto tests, I've pulled it into the top of the directory.
