### PR TITLE
Bug 1023345 - 1.4 semiauto webapi test updates

### DIFF
--- a/webapi_tests/semiauto/testcase.py
+++ b/webapi_tests/semiauto/testcase.py
@@ -202,7 +202,7 @@ def turn_screen_on(marionette):
 
 def unlock_screen(marionette):
     marionette.execute_script("""
-        var lockScreen = window.wrappedJSObject.LockScreen;
+        var lockScreen = window.wrappedJSObject.lockScreen || window.wrappedJSObject.LockScreen;
         lockScreen.unlock();
     """)
 

--- a/webapi_tests/telephony/test_telephony_incoming.py
+++ b/webapi_tests/telephony/test_telephony_incoming.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import time
+import unittest
 
 from webapi_tests.semiauto import TestCase
 from webapi_tests.telephony import TelephonyTestCommon
@@ -15,6 +16,7 @@ class TestTelephonyIncoming(TestCase, TelephonyTestCommon):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
 
+    @unittest.skip("Currently disabled in 1.4")
     def test_telephony_incoming(self):
         # ask user to call the device; answer and verify via webapi
         self.user_guided_incoming_call()

--- a/webapi_tests/telephony/test_telephony_outgoing.py
+++ b/webapi_tests/telephony/test_telephony_outgoing.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import time
+import unittest
 
 from webapi_tests.semiauto import TestCase
 from webapi_tests.telephony import TelephonyTestCommon
@@ -15,6 +16,7 @@ class TestTelephonyOutgoing(TestCase, TelephonyTestCommon):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
 
+    @unittest.skip("Currently disabled in 1.4")
     def test_telephony_outgoing(self):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()


### PR DESCRIPTION
Fix lockscreen for 1.4 (needed for all of the semiauto tests). Disable the telephony tests for 1.4 for now, as they will just fail (enable them once a solution is found for disabling the dialer agent in 1.4).
