### PR TITLE
Fix telephony test frame error

### DIFF
--- a/webapi_tests/telephony/telephony_test.py
+++ b/webapi_tests/telephony/telephony_test.py
@@ -229,6 +229,7 @@ class TelephonyTestCommon(object):
     def disable_dialer(self):
         # disable system dialer agent so it doesn't steal the
         # incoming/outgoing calls away from the certest app
+        cur_frame = self.marionette.get_active_frame()
         self.marionette.switch_to_frame() # system app
         try:
             self.marionette.execute_async_script("""
@@ -237,13 +238,13 @@ class TelephonyTestCommon(object):
             marionetteScriptFinished(1);
             """, special_powers=True)
         except:
-            self.marionette.switch_to_frame(self.app["frame"])
             self.fail("failed to disable dialer agent")
         finally:
-            self.marionette.switch_to_frame(self.app["frame"])
+            self.marionette.switch_to_frame(cur_frame)
 
     def enable_dialer(self):
         # enable system dialer agent to handle calls
+        cur_frame = self.marionette.get_active_frame()
         self.marionette.switch_to_frame() # system app
         try:
             self.marionette.execute_async_script("""
@@ -252,7 +253,6 @@ class TelephonyTestCommon(object):
             marionetteScriptFinished(1);
             """, special_powers=True)
         except:
-            self.marionette.switch_to_frame(self.app["frame"])
             self.fail("failed to disable dialer agent")
         finally:
-            self.marionette.switch_to_frame(self.app["frame"])
+            self.marionette.switch_to_frame(cur_frame)


### PR DESCRIPTION
If disabling the dialer agent failed, the 'except' clause was switching back to the cert test app frame then failing the test (which closed the cert test app); then the 'finally' clause was trying to switch back to the cert test app frame again which would fail because the app was gone.

This fix is for all branches. NOTE: The telephony tests will fail on 1.3 and 1.4 because of Bug 997248; it is no longer possible to disable the gaia dialer agent. However the telephony tests will still work on 1.3T Tarako as disabling the dialer agent there still works. The telephony tests are currently disabled on 1.4 anyway as they need to be updated for the new promise.
