### PR TITLE
Fix: add py back into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ mozdevice >= 0.33
 mozlog >= 2.0
 moznetwork >= 0.24
 mozprocess >= 0.18
+py == 1.4.20
 wptserve >= 1.0.1
 wptrunner >= 0.3.13
 mozrunner >= 6.1


### PR DESCRIPTION
This previous change has broken the suite on master:

https://github.com/mozilla-b2g/fxos-certsuite/commit/2acee13c6959254c50a7b5bfd3d5252a83a86229#diff-b4ef698db8ca845e5845c4618278f29aL8

With this error:

File "build/bdist.linux-i686/egg/pkg_resources.py", line 1954, in load
  File "/home/rwood/fxos-certsuite/certsuite_venv/local/lib/python2.7/site-packages/fxos_certsuite-0.1-py2.7.egg/certsuite/**init**.py", line 5, in <module>
    from harness import main as harness_main
  File "/home/rwood/fxos-certsuite/certsuite_venv/local/lib/python2.7/site-packages/fxos_certsuite-0.1-py2.7.egg/certsuite/harness.py", line 28, in <module>
    import report
  File "/home/rwood/fxos-certsuite/certsuite_venv/local/lib/python2.7/site-packages/fxos_certsuite-0.1-py2.7.egg/certsuite/report/**init**.py", line 13, in <module>
    import subsuite
  File "/home/rwood/fxos-certsuite/certsuite_venv/local/lib/python2.7/site-packages/fxos_certsuite-0.1-py2.7.egg/certsuite/report/subsuite.py", line 7, in <module>
    from py.xml import html, raw
ImportError: No module named py.xml

Adding back the requirement for 'py' fixes it.
