### PR TITLE
[1.4 only] Fix semiauto SMS and MMS tests

### DIFF
--- a/webapi_tests/mobile_message/__init__.py
+++ b/webapi_tests/mobile_message/__init__.py
@@ -9,5 +9,3 @@ from webapi_tests.mobile_message.test_sms_incoming_get_message import TestSmsInc
 from webapi_tests.mobile_message.test_sms_outgoing import TestSmsOutgoing
 from webapi_tests.mobile_message.test_mms_incoming import TestMmsIncoming
 from webapi_tests.mobile_message.test_mms_incoming_delete import TestMmsIncomingDelete
-from webapi_tests.mobile_message.test_mms_incoming_get_message import TestMmsIncomingGetMessage
-from webapi_tests.mobile_message.test_mms_outgoing import TestMmsOutgoing


### PR DESCRIPTION
Mistakenly checked in **init** that had tests that are under development and not complete, which breaks the semiauto MMS tests. Note, this is for 1.4 only as the MMS tests are not currently in the 1.3 branch.
