### PR TITLE
Bug 1026710 - Bump requirements for mozdevice and mozlog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 fxos-appgen >= 0.5
 marionette_client >= 0.7.10
 marionette_extension >= 0.4
-mozdevice >= 0.33
-mozlog >= 2.0
+mozdevice >= 0.38
+mozlog >= 2.1
 moznetwork >= 0.24
 mozprocess >= 0.18
 py == 1.4.20


### PR DESCRIPTION
We have recently released mozdevice 0.38 and mozlog 2.1.
These are required for https://bugzilla.mozilla.org/show_bug.cgi?id=1026710
