### PR TITLE
Fix requirements conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ py == 1.4.20
 wptserve >= 1.0.1
 wptrunner == 0.3.13
 mozrunner >= 6.1
-moztest == 0.5
+moztest >= 0.6
 sphinx
 tornado >= 3.2


### PR DESCRIPTION
There is a new conflict during run.sh certsuite_venv setup. Requirements was installing moztest==0.5; however further along in the setup mozversion is requiring moztest>=0.6, causing this break:

  File "build/bdist.linux-i686/egg/pkg_resources.py", line 569, in resolve
pkg_resources.VersionConflict: (moztest 0.5 (/home/rwood/fxos-certsuite/certsuite_venv/lib/python2.7/site-packages/moztest-0.5-py2.7.egg), Requirement.parse('moztest>=0.6'))
