### PR TITLE
Bug 1042776 - Log suite_start/suite_end events in semiauto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ py == 1.4.20
 wptserve >= 1.0.1
 wptrunner == 0.3.13
 mozrunner >= 6.1
-moztest == 0.5
+moztest >= 0.6
 sphinx
 tornado >= 3.2

--- a/webapi_tests/semiauto/runner.py
+++ b/webapi_tests/semiauto/runner.py
@@ -59,10 +59,12 @@ def run(suite, logger, spawn_browser=True, verbosity=1, quiet=False,
     so.suite = suite
     environment.env.handler = so
 
+    logger.suite_start(tests=tests)
     try:
         results = test_runner.run(suite)
     except (SystemExit, KeyboardInterrupt) as e:
         sys.exit(1)
+    logger.suite_end()
 
     return results
 


### PR DESCRIPTION
This resolves the pinning of moztest to version 0.5.
