### PR TITLE
Bug 997248 - Disable telephony tests on 1.3

### DIFF
--- a/webapi_tests/telephony/test_telephony_incoming.py
+++ b/webapi_tests/telephony/test_telephony_incoming.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import time
+import unittest
 
 from webapi_tests.semiauto import TestCase
 from webapi_tests.telephony import TelephonyTestCommon
@@ -30,6 +31,7 @@ class TestTelephonyIncoming(TestCase, TelephonyTestCommon):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
 
+    @unittest.skip("Currently disabled in 1.3, bug 997248")
     def test_telephony_incoming(self):
         # ask user to call the device; answer and verify via webapi
         self.user_guided_incoming_call()

--- a/webapi_tests/telephony/test_telephony_outgoing.py
+++ b/webapi_tests/telephony/test_telephony_outgoing.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import time
+import unittest
 
 from webapi_tests.semiauto import TestCase
 from webapi_tests.telephony import TelephonyTestCommon
@@ -30,6 +31,7 @@ class TestTelephonyOutgoing(TestCase, TelephonyTestCommon):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()
 
+    @unittest.skip("Currently disabled in 1.3, bug 997248")
     def test_telephony_outgoing(self):
         # disable the default dialer manager so it doesn't grab our calls
         self.disable_dialer()


### PR DESCRIPTION
Unable to disable the default gaia dialer in the 1.3, so disable the telephony tests.
