### PR TITLE
Bug 1032119 - Fix sdcard tests

### DIFF
--- a/certsuite/config.json
+++ b/certsuite/config.json
@@ -1,6 +1,7 @@
 {"version": "2.0",
  "suites": [
-            ["webapi", {"cmd": "webapirunner"}],
+            ["webapi", {"cmd": "webapirunner",
+                        "run_args": ["--version=%(version)s"]}],
             ["cert", {"cmd": "cert",
                       "run_args": ["--version=%(version)s",
                                    "--result-file=%(temp_dir)s/cert_results.json",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fxos-appgen >= 0.6
+fxos-appgen >= 0.7
 gaiatest == 0.26
 marionette_client == 0.7.10
 marionette_extension >= 0.4

--- a/webapi_tests/certapp.py
+++ b/webapi_tests/certapp.py
@@ -31,7 +31,7 @@ class CloseError(Exception):
     pass
 
 
-def install(marionette=None):
+def install(marionette=None, version='1.3'):
     """Installs the app on the attached device.  Raises if app is
     already installed, but a guard can be added using ``is_installed``.
 
@@ -42,7 +42,7 @@ def install(marionette=None):
     # fxos_appgen will create a new Marionette instance if unspecified
     fxos_appgen.generate_app(name,
                              install=True,
-                             version="1.3",
+                             version=version,
                              all_perm=True,
                              marionette=marionette)
 

--- a/webapi_tests/device_storage/device_storage_test.py
+++ b/webapi_tests/device_storage/device_storage_test.py
@@ -44,7 +44,7 @@ class DeviceStorageTestCommon(object):
         };
         request.onerror = function () {
             console.log("Unable to write the file: " + this.error.name);
-            marionetteScriptFinished(this.error.name);
+            marionetteScriptFinished("Unable to write the file: " + this.error.name);
         };
         """, script_args=[file_name, file_contents])
         return ret_namedfile_sdcard
@@ -74,7 +74,7 @@ class DeviceStorageTestCommon(object):
         }
         request.onerror = function (error) {
             console.log('Unable to remove the file: ' + this.error.name);
-            marionetteScriptFinished(false);
+            marionetteScriptFinished('Unable to remove the file: ' + this.error.name);
         }
         """, script_args=[file_name])
         return ret_file_delete_sdcard

--- a/webapi_tests/device_storage/test_sdcard_storage.py
+++ b/webapi_tests/device_storage/test_sdcard_storage.py
@@ -11,55 +11,52 @@ from webapi_tests.device_storage import DeviceStorageTestCommon
 class TestSdcardStorage(TestCase, DeviceStorageTestCommon):
 
     def setUp(self):
-        self.file_name = "test_sdcard_certsuite"
+        self.file_name = "certsuite_sdcard_testfile"
         self.file_contents = "This is a sample text file"
         self.addCleanup(self.clean_up)
         super(TestSdcardStorage, self).setUp()
         self.wait_for_obj("window.navigator.getDeviceStorage")
-        self.marionette.execute_script("window.wrappedJSObject.sdcard = navigator.getDeviceStorage(\"sdcard\")")
+        self.marionette.execute_script("window.wrappedJSObject.sdcard = navigator.getDeviceStorage(\"sdcard\"); log('sdcard=window.wrappedJSObject.sdcard');")
 
-    @unittest.skip("Currently disabled, see bug 1016295")
     def test_sdcard_availability(self):
         ret_check_sdcard = self.is_sdcard_available()
         self.assertEqual(True, ret_check_sdcard, "SDCard is unavailable. "
                         "Please ensure there is an SD card in the device and "
                         "usb storage sharing is not enabled")
 
-    @unittest.skip("Currently disabled, see bug 1016295")
     def test_add_namedfile_sdcard(self):
         if self.is_sdcard_available():
             #add the file to sdcard
             ret_add_namedfile_sdcard = self.add_namedfile_sdcard(self.file_name,
                                                             self.file_contents)
 
-            self.assertEqual(True, ret_add_namedfile_sdcard, "Unable "
-                             "to add the file")
+            self.assertEqual(True, ret_add_namedfile_sdcard, ret_add_namedfile_sdcard)
             #delete the file for cleanup
-            if self.delete_file_sdcard(self.file_name) is False:
-                self.fail("Failed to delete the file")
+            result = self.delete_file_sdcard(self.file_name)
+            if result is not True:
+                self.fail(result)
         else:
             self.fail("Sdcard is unavailable")
 
-    @unittest.skip("Currently disabled, see bug 1016295")
     def test_get_file_sdcard(self):
         if self.is_sdcard_available():
-            if self.add_namedfile_sdcard(self.file_name, self.file_contents):
+            if self.add_namedfile_sdcard(self.file_name, self.file_contents) is True:
                 #get the file from sdcard
                 ret_file_abspath_sdcard = self.get_file_sdcard(self.file_name)
                 if ret_file_abspath_sdcard is False:
                     self.fail("Not Found the file")
                 #delete the file for cleanup
-                if self.delete_file_sdcard(self.file_name) is False:
-                    self.fail("Failed to delete the file")
+                result = self.delete_file_sdcard(self.file_name)
+                if result is not True:
+                    self.fail(result)
             else:
                 self.fail("Unable to add the file")
         else:
             self.fail("Sdcard is unavailable")
 
-    @unittest.skip("Currently disabled, see bug 1016295")
     def test_delete_file_sdcard(self):
         if self.is_sdcard_available():
-            if self.add_namedfile_sdcard(self.file_name, self.file_contents):
+            if self.add_namedfile_sdcard(self.file_name, self.file_contents) is True:
                 #delete the file
                 ret_file_delete_sdcard = self.delete_file_sdcard(self.file_name)
                 self.assertEqual(True, ret_file_delete_sdcard, "Unable to "
@@ -69,18 +66,18 @@ class TestSdcardStorage(TestCase, DeviceStorageTestCommon):
         else:
             self.fail("Sdcard is unavailable")
 
-    @unittest.skip("Currently disabled, see bug 1016295")
     def test_enumerate_files_sdcard(self):
         if self.is_sdcard_available():
-            if self.add_namedfile_sdcard(self.file_name, self.file_contents):
+            if self.add_namedfile_sdcard(self.file_name, self.file_contents) is True:
                 #enumerate the files
                 filelist_sdcard_unicode = self.enumerate_files_sdcard()
                 self.assertNotEqual(0, len(filelist_sdcard_unicode), "There "
                                  "should be at least one file added as part "
                                  "of this test")
                 ret_file_delete_sdcard = self.delete_file_sdcard(self.file_name)
-                if self.delete_file_sdcard(self.file_name) is False:
-                    self.fail("Failed to delete the file")
+                result = self.delete_file_sdcard(self.file_name)
+                if result is not True:
+                    self.fail(result)
             else:
                 self.fail("Unable to add the file")
         else:
@@ -89,8 +86,9 @@ class TestSdcardStorage(TestCase, DeviceStorageTestCommon):
     def clean_up(self):
         #As each test is using the same file, get and delete the file if any test fails in between
         if self.get_file_sdcard(self.file_name) is True:
-            if self.delete_file_sdcard(self.file_name) is False:
-                self.fail("Failed to delete the file in clean up")
+            result = self.delete_file_sdcard(self.file_name)
+            if result is not True:
+                self.fail(result)
         self.file_name = None
         self.file_contents = None
         self.marionette.execute_script("window.wrappedJSObject.sdcard = null")

--- a/webapi_tests/runner.py
+++ b/webapi_tests/runner.py
@@ -78,6 +78,8 @@ def main():
                         "groups by repeating flag")
     parser.add_argument("-n", "--no-browser", action="store_true",
                         help="Don't start a browser but wait for manual connection")
+    parser.add_argument("--version", action="store", dest="version",
+                        help="B2G version")
     parser.add_argument(
         "-v", dest="verbose", action="store_true", help="Verbose output")
     commandline.add_logging_group(parser)
@@ -102,7 +104,7 @@ def main():
                 print("%s.%s" % (group, test))
         return 0
 
-    test_loader = semiauto.TestLoader()
+    test_loader = semiauto.TestLoader(version=args.version)
     tests = test_loader.loadTestsFromNames(
         map(lambda t: "webapi_tests.%s" % t, args.include or [g for g, _ in testgen]), None)
     results = semiauto.run(tests,

--- a/webapi_tests/semiauto/loader.py
+++ b/webapi_tests/semiauto/loader.py
@@ -15,8 +15,10 @@ class TestLoader(unittest.loader.TestLoader):
     """
 
     def __init__(self, **kwargs):
+        version = kwargs.pop('version')
         super(TestLoader, self).__init__()
         self.opts = kwargs
+        self.opts.update({'version': version})
 
     def loadTestsFromTestCase(self, klass):
         """Return a suite of all tests cases contained in ``klass``.

--- a/webapi_tests/semiauto/testcase.py
+++ b/webapi_tests/semiauto/testcase.py
@@ -26,6 +26,7 @@ class TestCase(unittest.TestCase):
     stored = threading.local()
 
     def __init__(self, *args, **kwargs):
+        self.version = kwargs.pop('version')
         super(TestCase, self).__init__(*args, **kwargs)
         self.stored.handler = None
         self.stored.marionette = None
@@ -67,7 +68,7 @@ class TestCase(unittest.TestCase):
         self.marionette = TestCase.create_marionette()
 
         if not certapp.is_installed():
-            certapp.install(self.marionette)
+            certapp.install(marionette=self.marionette, version=self.version)
 
         # Make sure we don't reuse the certapp context from a previous
         # testrun that was interrupted and left the certapp open.


### PR DESCRIPTION
These tests were failing for multiple reasons.  The semiauto harness was hardcoded to pass a version of "1.3" to fxos_appgen, which in turn had incorrect permissions for sdcard access.

I've already patched fxos_appgen.  This PR allows us to pass a --version parameter to semiauto and have it used to generate the test app.  It also re-enables the sdcard tests, and they all pass with this patch on a 2.0 Flame.
