### PR TITLE
Fix apps webapi tests

### DIFF
--- a/webapi_tests/apps/apps_test.py
+++ b/webapi_tests/apps/apps_test.py
@@ -8,9 +8,14 @@ class AppsTestCommon(object):
         app = self.marionette.execute_async_script("""
         let request = navigator.mozApps.getSelf();
         request.onsuccess = function() {
-            marionetteScriptFinished(request.result);
+            let result = {};
+            result['manifest'] = request.result['manifest'];
+            result['origin'] = request.result['origin'];
+            marionetteScriptFinished(result);
         };
-        request.onerror = function() { throw req.error.name };
+        request.onerror = function() {
+            throw request.error.name;
+        };
         """)
         self.assertIsNotNone(app, "mozApps.getSelf returned none")
         return app
@@ -19,9 +24,16 @@ class AppsTestCommon(object):
         applist = self.marionette.execute_async_script("""
         let request = navigator.mozApps.mgmt.getAll();
         request.onsuccess = function() {
-            marionetteScriptFinished(request.result);
+            let resultlist = [];
+            for (let i in request.result) {
+                let result = {};
+                result['manifest'] = request.result[i]['manifest'];
+                result['origin'] = request.result[i]['origin'];
+                resultlist.push(result);
+            }
+            marionetteScriptFinished(resultlist);
         };
-        request.onerror = function() { throw req.error.name };
+        request.onerror = function() { throw request.error.name };
         """)
         self.assertIsNotNone(applist, "mozApps.mgmt.getAll returned none")
         return applist

--- a/webapi_tests/apps/test_apps_basic.py
+++ b/webapi_tests/apps/test_apps_basic.py
@@ -12,13 +12,11 @@ class TestAppsBasic(TestCase, AppsTestCommon):
         super(TestAppsBasic, self).setUp()
         self.wait_for_obj("window.navigator.mozApps")
 
-    @unittest.skip("Bug 1110545 - test times out")
     def test_get_self(self):
         app = self.get_self()
         self.assertEqual(app["manifest"]["name"], "CertTest App", "Application name is different from CertTest App")
         self.assertEqual(app["manifest"]["description"], "Generated app", "Application description is different from Generated app")
 
-    @unittest.skip("Bug 1110545 - test times out")
     def test_get_all(self):
         applist = self.get_all()
         for app in applist:


### PR DESCRIPTION
The tests were failing on 2.1 because we were trying to return complex, non-serializable objects.  I've modified the tests to only return the properties we actually use, and they now pass.