### PR TITLE
Pinning wptrunner == 1.4 because no later version works. Fixes bug 1124710

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ moztest >= 0.6
 py == 1.4.20
 sphinx
 tornado >= 3.2
-wptrunner >= 1.4
+wptrunner == 1.4
 wptserve >= 1.0.1


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1124710