### PR TITLE
Bug 1135094 - "make test" fails with "No module named semiauto"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: test docs
 
 test:
 	adb forward tcp:2828 tcp:2828
-	python -m semiauto webapi_tests.semiauto.smoketests | python -m mozlog.structured.scripts.format mach 2>/dev/null
+	python -m webapi_tests.semiauto webapi_tests.semiauto.smoketests | python -m mozlog.structured.scripts.format mach 2>/dev/null
 
 dist:
 	python setup.py sdist

--- a/webapi_tests/semiauto/loader.py
+++ b/webapi_tests/semiauto/loader.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
+import json
 import unittest
 
 
@@ -15,7 +17,13 @@ class TestLoader(unittest.loader.TestLoader):
     """
 
     def __init__(self, **kwargs):
-        version = kwargs.pop('version')
+        try:
+            version = kwargs.pop('version')
+        except:
+            config_path = os.path.abspath(os.path.join(os.path.realpath(__file__), "../../../certsuite/config.json"))
+            with open(config_path) as f:
+                config = json.load(f)
+            version = config['version']
         super(TestLoader, self).__init__()
         self.opts = kwargs
         self.opts.update({'version': version})


### PR DESCRIPTION
fixing the module namespace.
loading the config file to get the version info.