### PR TITLE
fix for "NameError: global name logger is not defined"

### DIFF
--- a/certsuite/logmanager.py
+++ b/certsuite/logmanager.py
@@ -4,6 +4,8 @@ import time
 
 from datetime import datetime
 
+from mozlog.structured import get_default_logger
+
 class LogManager(object):
     def __init__(self):
         self.time = datetime.now()
@@ -23,6 +25,7 @@ class LogManager(object):
     def __exit__(self, ex_type, ex_value, tb):
         args = ex_type, ex_value, tb
         if ex_type in (SystemExit, KeyboardInterrupt):
+            logger = get_default_logger()
             logger.info("Testrun interrupted")
         try:
             self.structured_file.__exit__(*args)


### PR DESCRIPTION
The following error was triggered when you ctrl-c in the middle of a test run:

```
Encountered error at top level:
Traceback (most recent call last):
  File "/Users/cruetten/Documents/src/fxos-certsuite/certsuite/harness.py", line 405, in run_tests
    logger.critical("Encountered errors during run")
  File "/Users/cruetten/Documents/src/fxos-certsuite/certsuite/logmanager.py", line 29, in __exit__
    global logger
NameError: global name 'logger' is not defined
```