### PR TITLE
Bug 1147306 - [MCTS][v2.2] Orientation wording is incorrect when testing...

### DIFF
--- a/certsuite/report/subsuite.py
+++ b/certsuite/report/subsuite.py
@@ -207,15 +207,15 @@ class HTMLBuilder(object):
 
 def make_report(results):
     doc = HTMLBuilder().make_report(results)
-    with open('/tmp/test.html', 'w') as f:
-        print 'write file /tmp/test.html'
-        f.write(u"<!DOCTYPE html>\n" + doc.unicode(indent=2))
     return u"<!DOCTYPE html>\n" + doc.unicode(indent=2)
 
 def make_file_report(path):
     from __init__ import parse_log
     results = parse_log(path)
-    make_report(results)
+    with open('/tmp/test.html', 'w') as f:
+        print 'write file /tmp/test.html'
+        f.write(make_report(results))
+    
 
 if __name__ == "__main__":  
     import sys

--- a/certsuite/report/summary.py
+++ b/certsuite/report/summary.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import cgi
 import pkg_resources
 import base64
 import marionette.runner.mixins

--- a/webapi_tests/orientation/test_device_orientation.py
+++ b/webapi_tests/orientation/test_device_orientation.py
@@ -73,8 +73,8 @@ class TestDeviceOrientation(TestCase):
         self.instruct("Keep the phone on the surface and rotate the phone by more than 90 degrees "\
                       "then back to its starting position (z-axis test)")
         self.instruct("Pick up the phone and rotate the phone so the screen is perpendicular to the table, "\
-                      "so the screen is facing you, then hold it parallel to the floor (y-axis test)")
-        self.instruct("Rotate the phone left or right by more than 90 degrees and back to its starting position (x-axis test)")
+                      "so the screen is facing you, then hold it parallel to the floor (x-axis test)")
+        self.instruct("Rotate the phone left or right by more than 90 degrees and back to its starting position (y-axis test)")
         self.assertEqual(type(self.get_window_value("absolute")), bool, "expected absolute")
         self.assertTrue(self.get_window_value('alpha'), "expected alpha")
         self.assertTrue(self.get_window_value('beta'), "expected beta")


### PR DESCRIPTION
... device orientation

1. change 2nd and 3rd steps wording to y-axis(2nd step) and x-axis(3rd step).
2. fix miss import cgi in summary.py report
3. move test code from make_report to make_file_report in subsuite.py