### PR TITLE
Bug 1145548 - [MCTS][v2.2] input device profile read and write

### DIFF
--- a/certsuite/cert.py
+++ b/certsuite/cert.py
@@ -432,6 +432,13 @@ def _run(args, logger):
         return 0
 
     test_groups = set(args.include if args.include else test_groups)
+
+    if args.device_profile:
+        skiplist = []
+        with open(args.device_profile, 'r') as device_profile_file:
+            skiplist = json.load(device_profile_file)['result']['cert']
+        test_groups = [x for x in test_groups if x not in skiplist]
+
     report = {'buildprops': {}}
 
     logging.basicConfig()
@@ -782,6 +789,8 @@ def cli():
     parser.add_argument("--generate-reference",
                         help="Generate expected result files",
                         action="store_true")
+    parser.add_argument('-p', "--device-profile", action="store",  type=os.path.abspath,
+                        help="specify the device profile file path which could include skipped test case information")
     commandline.add_logging_group(parser)
 
     args = parser.parse_args()

--- a/certsuite/harness.py
+++ b/certsuite/harness.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import traceback
 import zipfile
+import webbrowser
 from cStringIO import StringIO
 from collections import OrderedDict
 from datetime import datetime
@@ -36,6 +37,8 @@ from marionette_extension import install as marionette_install
 from marionette_extension import uninstall as marionette_uninstall
 from mozfile import TemporaryDirectory
 from mozlog.structured import structuredlog, handlers, formatters, set_default_logger
+from webapi_tests.semiauto import environment, server
+
 from reportmanager import ReportManager
 from logmanager import LogManager
 
@@ -51,9 +54,8 @@ config_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "config.json"))
 
 
-def setup_logging(log_manager):
+def setup_logging(log_f):
     global logger
-    log_f = log_manager.structured_file
     logger = structuredlog.StructuredLogger("firefox-os-cert-suite")
     logger.add_handler(stdio_handler)
     logger.add_handler(handlers.StreamHandler(log_f,
@@ -200,7 +202,7 @@ class TestRunner(object):
 
         return output_files, structured_path
 
-    def build_command(self, suite, groups, temp_dir):
+    def build_command(self, suite, groups, temp_dir, device_profile=None):
         suite_opts = self.config["suites"][suite]
 
         subn = self.config.copy()
@@ -218,6 +220,17 @@ class TestRunner(object):
 
         cmd.extend(item % subn for item in suite_opts.get("run_args", []))
         cmd.extend(item % subn for item in suite_opts.get("common_args", []))
+        
+        if self.args.debug and suite == 'webapi':
+            cmd.append('-v')
+        if self.args.debug and suite == 'cert':
+            cmd.append('--debug')
+            
+        if self.args.device_profile or self.args.edit_device_profile:
+            if suite == 'webapi' or suite == 'cert':
+                device_profile = self.args.device_profile or self.args.edit_device_profile
+                cmd.append('--device-profile')
+                cmd.append(device_profile)
 
         output_files = [log_name]
         output_files += [item % subn for item in suite_opts.get("extra_files", [])]
@@ -373,6 +386,46 @@ def list_tests(args, config):
         print "%s:%s" % (test, group)
     return True
 
+def edit_device_profile(device_profile_path):
+    resp = ''
+    try:
+        env = environment.get(environment.InProcessTestEnvironment, addr=None, verbose=False)
+        url = "http://%s:%d/profile.html" % (env.server.addr[0], env.server.addr[1])
+        webbrowser.open(url)
+        environment.env.handler = server.wait_for_client()
+        
+        question = ''
+        resp = environment.env.handler.prompt(question)
+
+        message = 'Create device profile failed!!'    
+        if resp != '':
+            result = json.loads(resp)
+            if result['return'] == 'ok':
+                with open(device_profile_path, 'w') as device_profile_f:
+                    json.dump(result, device_profile_f, indent=4)
+                message = 'Create device profile successfully!!'
+            else:
+                message = 'Create device profile is cancelled by user!!'
+        else:
+            message = ''
+        logger.info(message)
+    except:
+        logger.error("Failed create device profile:\n%s" % traceback.format_exc())
+    
+    return True
+
+def check_device_profile(device_profile_path):
+    try:
+        with open(device_profile_path, 'r') as device_profile_file:
+            device_profile_string = device_profile_file.read()
+            device_profile_object = json.loads(device_profile_string)
+            if not 'result' in device_profile_object:
+                logger.error('Invalide device profile file [%s]' % device_profile_path)
+            else:
+                if not 'contact' in device_profile_object['result']:
+                    logger.error('Invalide device profile file [%s]' % device_profile_path)
+    except:
+        logger.critical("Encountered error at checking device profile file [%s]:\n%s" % (device_profile_path, traceback.format_exc()))
 
 def run_tests(args, config):
     error = False
@@ -381,7 +434,22 @@ def run_tests(args, config):
     try:
         with LogManager() as log_manager, ReportManager() as report_manager:
             output_zipfile = log_manager.zip_path
-            setup_logging(log_manager)
+            setup_logging(log_manager.structured_file)
+
+            if args.edit_device_profile:
+                report_manager.unlink_devcie_profile_file = False
+                report_manager.device_profile_path = args.edit_device_profile
+            else:
+                report_manager.device_profile_path = os.path.abspath('device_profile.json')
+            
+            if args.device_profile:
+                report_manager.unlink_devcie_profile_file = False
+                report_manager.device_profile_path = args.device_profile
+            else:
+                edit_device_profile(report_manager.device_profile_path)
+
+            check_device_profile(report_manager.device_profile_path)
+
             report_manager.setup_report(log_manager.zip_file, log_manager.structured_path)
 
             log_metadata()
@@ -400,7 +468,8 @@ def run_tests(args, config):
                                          traceback.format_exc())
                             error = True
                 finally:
-                    marionette_uninstall()
+                    if not args.debug:
+                        marionette_uninstall()
                     backup.restore()
                     device.reboot()
 
@@ -419,10 +488,19 @@ def run_tests(args, config):
 def get_parser():
     parser = argparse.ArgumentParser()
     #TODO make this more robust
-    parser.add_argument('--config',
+    parser.add_argument('-c', '--config',
                         help='Path to config file', type=os.path.abspath,
                         action='store', default=config_path)
-    parser.add_argument('--list-tests',
+    parser.add_argument('-d', '--debug',
+                        help='enable debug',
+                        action='store_true')
+    parser.add_argument('-e', '--edit-device-profile',
+                        help='Path to device profile file', type=os.path.abspath,
+                        action='store', default=None)
+    parser.add_argument('-p', '--device-profile',
+                        help='Path to device profile file', type=os.path.abspath,
+                        action='store')
+    parser.add_argument('-l', '--list-tests',
                         help='list all tests available to run',
                         action='store_true')
     parser.add_argument('tests',
@@ -439,8 +517,8 @@ def main():
 
     if args.list_tests:
         return list_tests(args, config)
-    else:
-        return run_tests(args, config)
+
+    return run_tests(args, config)
 
 
 if __name__ == '__main__':

--- a/certsuite/harness.py
+++ b/certsuite/harness.py
@@ -202,7 +202,7 @@ class TestRunner(object):
 
         return output_files, structured_path
 
-    def build_command(self, suite, groups, temp_dir, device_profile=None):
+    def build_command(self, suite, groups, temp_dir):
         suite_opts = self.config["suites"][suite]
 
         subn = self.config.copy()
@@ -417,8 +417,7 @@ def edit_device_profile(device_profile_path):
 def check_device_profile(device_profile_path):
     try:
         with open(device_profile_path, 'r') as device_profile_file:
-            device_profile_string = device_profile_file.read()
-            device_profile_object = json.loads(device_profile_string)
+            device_profile_object = json.loads(device_profile_file)
             if not 'result' in device_profile_object:
                 logger.error('Invalide device profile file [%s]' % device_profile_path)
             else:

--- a/certsuite/report/summary.py
+++ b/certsuite/report/summary.py
@@ -16,9 +16,9 @@ here = os.path.split(__file__)[0]
 rcname = marionette.runner.mixins.__name__
 
 class HTMLBuilder(object):
-    def make_report(self, time, summary_results, subsuite_results, log_path):
+    def make_report(self, time, summary_results, subsuite_results, logs):
         self.time = time
-        self.log_path = log_path
+        self.logs = logs
         self.summary_results = summary_results
         self.subsuite_results = subsuite_results
         return html.html(
@@ -59,14 +59,16 @@ class HTMLBuilder(object):
             body_parts.append(self.make_errors_table(self.summary_results.errors))
         body_parts.append(self.make_result_table())
 
-        details_log = ''
-        with open(self.log_path, 'r') as f:
-            details_log = f.read()
-        href = 'data:text/plain;charset=utf-8;base64,%s' % base64.b64encode(details_log)
-        body_parts.extend([
-            html.h2("Details log information"),
-            html.a(html.a('log', href=href, target='_blank'))
-            ])
+        if self.logs:
+            body_parts.append(html.h2("Details log information"))
+            ulbody = [];
+            for log_path in self.logs:
+                details_log = ''
+                with open(log_path, 'r') as f:
+                    details_log = f.read()
+                href = 'data:text/plain;charset=utf-8;base64,%s' % base64.b64encode(details_log)
+                ul.append(html.a(html.a(log__path, href=href, target='_blank')))
+            body_parts.append(html.ul(ulbody))
         return html.body(body_parts)
 
     def make_errors_table(self, errors):

--- a/certsuite/reportmanager.py
+++ b/certsuite/reportmanager.py
@@ -15,6 +15,7 @@ class ReportManager(object):
         self.zip_file = None
         self.subsuite_results = {}
         self.structured_path = None
+        self.unlink_devcie_profile_file = True
 
     def setup_report(self, zip_file = None, 
         structured_path = None):
@@ -25,9 +26,12 @@ class ReportManager(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, *arfs, **kwargs):
+    def __exit__(self, *args, **kwargs):
         if self.structured_path:
             self.add_summary_report(self.structured_path)
+        if self.unlink_devcie_profile_file:
+            os.unlink(report_manager.device_profile)
+            
 
     def add_subsuite_report(self, path, result_files):
         results = report.parse_log(path)
@@ -52,6 +56,6 @@ class ReportManager(object):
         html_str = report.summary.make_report(self.time,
                                               summary_results,
                                               self.subsuite_results,
-                                              path)
+                                              [path, self.device_profile])
         path = "report.html"
         self.zip_file.writestr(path, html_str)

--- a/webapi_tests/semiauto/static/profile.html
+++ b/webapi_tests/semiauto/static/profile.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this file,
+    You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Firefox OS MCTS </title>
+<style type="text/css">
+#tabzilla {
+  background-image: url('data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%9A%00%00%00%2A%08%06%00%00%00K5Bb%00%00%00%19tEXtSoftware%00Adobe%20ImageReadyq%C9e%3C%00%00%03"iTXtXML%3Acom.adobe.xmp%00%00%00%00%00%3C%3Fxpacket%20begin%3D"%EF%BB%BF"%20id%3D"W5M0MpCehiHzreSzNTczkc9d"%3F%3E%20%3Cx%3Axmpmeta%20xmlns%3Ax%3D"adobe%3Ans%3Ameta%2F"%20x%3Axmptk%3D"Adobe%20XMP%20Core%205.0-c060%2061.134777%2C%202010%2F02%2F12-17%3A32%3A00%20%20%20%20%20%20%20%20"%3E%20%3Crdf%3ARDF%20xmlns%3Ardf%3D"http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23"%3E%20%3Crdf%3ADescription%20rdf%3Aabout%3D""%20xmlns%3Axmp%3D"http%3A%2F%2Fns.adobe.com%2Fxap%2F1.0%2F"%20xmlns%3AxmpMM%3D"http%3A%2F%2Fns.adobe.com%2Fxap%2F1.0%2Fmm%2F"%20xmlns%3AstRef%3D"http%3A%2F%2Fns.adobe.com%2Fxap%2F1.0%2FsType%2FResourceRef%23"%20xmp%3ACreatorTool%3D"Adobe%20Photoshop%20CS5%20Macintosh"%20xmpMM%3AInstanceID%3D"xmp.iid%3A020E1A744EE711E1B998DDAEBC2F55D0"%20xmpMM%3ADocumentID%3D"xmp.did%3A020E1A754EE711E1B998DDAEBC2F55D0"%3E%20%3CxmpMM%3ADerivedFrom%20stRef%3AinstanceID%3D"xmp.iid%3A020E1A724EE711E1B998DDAEBC2F55D0"%20stRef%3AdocumentID%3D"xmp.did%3A020E1A734EE711E1B998DDAEBC2F55D0"%2F%3E%20%3C%2Frdf%3ADescription%3E%20%3C%2Frdf%3ARDF%3E%20%3C%2Fx%3Axmpmeta%3E%20%3C%3Fxpacket%20end%3D"r"%3F%3E%29%84uT%00%00%0A2IDATx%DA%EC%5CyL%14Y%1E~%DC%87r%18%03%8A%07%87GD%82%12%E1%0F%0F%94%F5%80%A8%B3%7Fx%AE%21%82%1Awv%8C%8EN%C6%B8%EB%EE%CA%C6%D5%8C%9Bqv%5DY%CFa%E2%B8kX%24%12%CF%89Q%3C%40%1DM%00W%07%A3%06%01o%D4I%14P%01E%81ni%F6%7D%8Fzeu5%D5%DDtWA%F7%A4%BE%E4%A5%AB%EAU%BDzU%BF%EF%FD%AE%F7%BA%3C%3A%3A%3A%88%87%87%87%D7%B9s%E7"CBB%A2ccc3%E8%EF%A7D%87%0E%27%F1%F2%E5%CB-aaa%FF%A4%9B%06%02%A2Qx%D2%E2CK%00-%C1yyy%09o%DF%BE%3D%D6%A1C%87%03%00w%C0%21%CA%A5%20Z%FCh%F1%F6%104%1A%C8%E6%21%14N%3A%DF%1B7n%FC%2A%3E%3E%FE%1B%1F%1F%9F%D1%FA%F8%D4a%0BF%A3%B1%AA%A2%A2%E2%CF%89%89%89%97%E9n%1B-%1Fhi%A7%A5%83k49%3C%04%B2%05%CE%981c%40cc%E3~%7D%9C%EA%B0%06p%04%5C%01g%04%EEx%98%11J%A2%D1%BA%02%D7n~O%9E%3C%F9mdd%24%EC%AD%97%3EvuH%D0%FE%F4%E9%D3%3FDEE%FDG%D0bFZL%5D%11%C9%1AL%CC%91%23%A4%856%B4%FF%DE%BD%7B%9F%0A%AAP%87%02%5E%BDzE%E8%A0T%ACG%DD%FB%F7%EF%BB%AC%C3%F1%C7%8F%1F%BB%15%C9%C0%09p%03%1C%11%B8b%EA%D2D%DA%D0hRS%0AM%E6G_Dftt%F4w%3A%A5%2C%B1m%DB6r%F1%E2E%B6%3Dj%D4%28%B2c%C7%0E%B6M%23zV8%C96o%DEL%C6%8F%1F%CF%233r%E0%C0%01r%EB%D6-FR%E9u%AE%8E%9A%9A%9A%95111%07%05M%D6%E9%8BY1%8D%F6%A0Ch%A8%8D6%9C%FF%FA%F5%EB%7F%E9%B4%B2%D4T%9Cd%C0%DD%BBwIYY%19%DB%AE%AB%AB%23UUU%A2%26%A3Z%40%3C%EF%C5%8B%17%EC%3A%90%0C%F0%F2r%0F%CF%04%1C%00%17%EC%21Yw%88%26%25%5B%2Bu%FA%BE2%18%0C%FF%D3%E9%F5%114%A4W%3C%26%B7%18%D2%FD%88%88%08%B7%7BV%C8%1E%1C%00%17%EC%21Yw%89%26%92%ED%E6%CD%9B%EF%2F%5D%BA%F495%BBF%9Db%9D%88%8F%8F%27C%87%0E%15%F7%03%03%03%C9%E4%C9%93m%5E%D7%BF%7F%7F%B7zN%C8%1C%B2%07%07%EC%25%19%E0%ED%C8%BD%90%1F%995kVUCC%C3%B7%A1%A1%A1_%EA4%EB%04%7C%2B%98%CB%E6%E6f%92%96%96%C6%C8%F6KCSS%D3%B7%90%3D8%80%B4%86%1D%FE%BD%C3D%E3%D1%A8q%E7%CE%9D%DFl%DC%B81%D3%D3%D3S%93aI%C3fr%FD%FAu2u%EAT%12%10%10%C0%1Cj%08%11%01%CC%B4i%D3D%0D%02%DF%87%D7%01%23G%8E%24%13%26LPl%F7%D9%B3g%84%8EJB%FB%CD%DA%1A8p%20INN%B6%20FEE%05%3B%C7%EA%8B0%99%C8%B0a%C3%D8%B5---d%C8%90%21%A4%BC%BC%9C%1C9r%84%2C%5B%B6L%D5%F7q%F5%EAUr%FF%FE%7D%D1%F4%E2%DE%D2%F7%A05%E8%FD%5EA%E6%90%3D%7Do%A6%EE%5Cko%D4%A9%14%89%FAR%AD%F65%D5j%EB%D4%7C%A0%92%92%12%92%9D%9D-%3A%CFc%C7%8E%25%0F%1E%3C%B0H%0B%2CY%B2%84%0C%1E%3C%98%EC%DA%B5%CB%A2%0E%2F%1F%1AFJ%1E%10l%CB%96-%ECW%0E%9C%B7z%F5j2%7D%FAt%F1%D8%EC%D9%B3%ED%8E6a%3A%D7%AE%5D%CB%82%00%8E3g%CE%B0%DF%83%07%0F%92%FC%FC%7C%F1xFF%06%C9%CC%CC%EC%F2%3Eqqqd%FB%F6%EDf%29%8F%E3%C7%8F%93%13%27N%28%A6E%D0%E7%F5%EB%D7kN%B4%C6%C6%C6%EC~%FD%FAe%C1M%EB%102%FDZk4%D1%84%16%15%15%E5%2C%5C%B8%F0%0BzC%1F%B5%1Eh%DC%B8qf%2F%F5%F6%ED%DB%5D%9E%97%97%97gUk%9D%3F%7F%9E%CC%9D%3BW%CCo%81%08%D6rX%20%0C%17%5Cw%C0%B5%9E%16%11%23%06%93R%9F9%10%B5%E2%9D%A5%A6%A6j%EA%9BA%D6%DCdv%F7zog%B5%E9%A2E%8B~%A6%26%E3G%7F%7F%FF4%B5%1EJ%C9%B7%998q"%FB%E5i%03y%1D%A2%3C%98%3B%0EhA%0Eh2%A9%C0%A0%F1V%AE%5CI%AA%AB%AB%CD%08%0B%B2%25%24%240%27%3D%3D%3D%DD%8C%3C%D8.--5k%17%E8%D3%A7%8Ff%02%9E7o%9E%996%84K%80%5C%DB%A9S%A7%C4%94%08p%E5%CA%15M%89%D6%D6%D6%F6%23dM%14%12%B2Z%13%8DE%A1T%A5%FE%40%FD%9C4%AD%1E%12B%A7%BE%81%18%A1IM%0D%8Em%DD%BA%95%11%07DZ%B0%60%81X%F7%FC%F9sQ%9BIM%1Aw%DCA%E8%C4%C4Dv%5Eqq%B1Xw%F8%F0a%B2j%D5%2A%0B%1F%0B%ED%1C%3Dz%D4%EC%D8%9C9sHTT%94f%02%9E%3F%7F%3E9%7B%F6%2C%F3%21%D1%1F%3E%08%11lH%CD%EF%BBw%EF%B46%9B%3F%40%D6%8Eh3G%D2%1B%5D%A1%FD%C2%85%0B%27%89%86SSp%D6%95%D2%00%A8%E3%CE%B0%92%26%C4h%97%A7"%A4%E7%A6%A4%A4%98%D5%CB5%16%C7%86%0D%1B%2C%B4%E2%D2%A5K5%150%FA%09%1F%0F%C4%C76%C8~%E7%CE%1D6%A3%D0%83pZ%C6%DE%2At%A2%83%8E%AC%97T%ADV%F8%F8%F8%24h%E4%1F8T%C7%C1%A3Q%25%D3%2C7%7D555%16m%E4%E4%E4X%04%114%E2%EE%91%14%06f%15%0A%0A%0A%98%5B%60%CB_%D3%02F%A3%B1%022%B67g%A6%09%D1%84%5CJ%BB%C1%60%B8%A9%15%D1%9C%85%3C2%82%8Fc%0Dra%C2%EC%9E%3Cy%D2%EC%18"%C7%9EH%2B%C0%D1%E7AJo%01%B2u%C6l%AAe%3A%19%DF%A8p~r%D5%24%A3%FC%FD%C8%FD5k%C1%08H%97%95%95eAT%A9%7F%A4%15p%EF%BD%7B%F7Z%F8%AB%08%10%D4%CE%D1%D9%E8%C7O%CEh3%B5L%27%93emm%ED%8D%B0%B00%97%24ZPP%90%D9%BE%DCq%96%EFGGG%8B%DB%20%99T%C3%81%840%99%3D%81G%8F%1E%99%DD%1B%24%DB%B7o%1F%EB%03%8E%E7%E6%E6%F6H%3F%20%5Bg%89%A6%96F3%ED%DE%BD%FB%0E%E9%5C%8F%E4r%40d%29%85%7C%CD%97%3CX%181b%04%FB%85%B9%94k%BF5k%D68%3D%3Fim%B6AZ%27%3F%0F%13%F0%5C%DB%CA%D7%BC9%98t%B7%CBr%0A%B259%D3%88%2A%1AM%F0%D3Z%F7%EC%D9%83%80%20%D1%D5%88%16%19%19IbccY%CE%8C%9B%A4M%9B6%91%C5%8B%17%5B%A46%00%1A%D80%C7%1F%01%80%14%98j%1A4h%10%A9%AC%AC43%CB%D0%E4%E1%E1%E1%CA%A3%D0d.%23L%23%29%81%3B%FC%20%94%FC%3Ah8%F4%0BD%2F%2C%2C4%AB%C3r%23%AD%02%01%AAE%5B%9D%F1%CF%D44%9D%EC%7D%B6%B4%B4%5CqE%A2%01%EB%D6%AD3%9B%19%B8v%ED%1A%2Br%C0%C9%87%20O%9F%3E%DD%A5%29C%1Br%E0%D8%CC%993%15%EF%8D%F9%C8C%87%0E%89%FB%98%B3D%BE%EF%D8%B1c%A2I%94%26_Q%87%C5%91c%C6%8C%11%CD%24%1F%20%2BV%AC%E8%F2%1E%B8%1EA%83%DASQ%90%A9%B3%DALM%D3%C9%88VWWwF%93%24N%7B%BB%D3u%7C%EE%D3%9A%D9%93%CEAvg%00O%992%C5j_poy%A4%0B%D2%F04%CA%F2%E5%CB-%AE%C1%A4%3F%9F%7FU%02%9EE%1A%B8%24%25%25%A9%FE%EE%05%99%3AM4g%26%D5%CD%04B%DB%F0LNN%EEC%FD%9DJ%EA%5B%0Cq%B6c%D2%95%13X%B9%11%13%13%E3t%1DGQQ%11y%F8%F0%21%F3%BF0%29%0F%9F%0Cd%91%92%B0%BE%BE%9E%AD%8C%B5%F5n%90%83%E33%03%F0%FD%B0%82%83%9BK%24%86%A5%80%89%86%3F%88%A92%F8%8D%93%26M"%C3%87%0Fgu0%C7%97%2F_f%ABoa%9E%B1%96%8DO%B9%A1%0E%1A%96%9BG%B4%8D%EB%A1%F9%A0%C9%90H%86F%C5%BC%A8%9A%A0%F7%F99%25%25%25%AE%A4%A4%E4%9D%D2j%0D%7B%B9%A3%1A%D1%84%9B%FA%BEy%F3f%2F%8D%F2~Gt%B8%3D%E8%80%D8%1F%1C%1C%BC%9A%CAX1%C8%B3%97%3B%9E%2A%F7%CDD5%CA%F7D%FF%A7%D4%2F%01%ED%82%2CMj4%A6%B6FCC%FE%D4%7C%1C%F1%F7%F7%FF%B5.%2B%F7Ekk%EBi%EAz%FC%06%9B%D6"%CE%5E%D1hB%87%3EP%3F%23%5B%17%95%7BC%90%E1%07g%D3%1A%9Ah4%1E%14%D0%1F%3Fj%DF%BF%EF%DB%B7o%86.2%F7Csss%3E%F5%B3%3F%A3%9Bm%B6%96l%F7%96%8FF%84%8E%19sss%FF%825%E6%BA%D8%DC%0B%90%19dG%1C%F8_%40%8Fj4%89%AF%E6WUU%F5Ill%ECa%A2%7F%AF%C3m%02%80%EA%EA%EAE%A3G%8F.%14%B4%99M%B3%D9%2B%E9%0DY%07%D8%27%14jkk%7F%1F%1E%1E%FE%95.C%D7G%5D%5D%DD_%07%0C%18%B0%5D%20%99%5D%99%83%5E%27%9A%D0%09Lq%F9766%FE%23%24%24d%95.J%D7ESSSNhh%E8%1F%85%28%F3%83%DD%26%B1%B7%7C4%B9%2A%C6%E8%A0%0F%F0%A7%FA%FA%FA%BF%11%3D%BF%E6%92%E6%12%B2%81%8C%C8%C7%EFh%A8%0EM%89%C6%D3%1D%18%25%D4%7C%FE%BD%B4%B4%F4%13%A3%D1%F8P%97%ADk%00%B2%80L%20%1B%D2%F9%1D%0D%D5%D2%19%DD2%7D%F6%5Eo%AB%90%CE%3F%1B%C3%8C%06fffF444%FC%5B%FFFb%EF%022%80%2CH%E7%17%1A%BD%B9%1B%D5%DD%E2RD%93t%8A%E5%D8h%09.%2B%2B%9B%DD%DC%DC%5C%A8%8B%BCg%81w%8Ew%0F%19%08%B2%F0t%84%60%DD%25%9A%A6%C1%80%82%F3%C8%3F%EA%C7%3E%C8%5C%5E%5E%9E%12%17%17%97%E5%E7%E7%97%40%AB%02t%83%A6%89%D5jikk%BBUYY%F9uRR%12%D6%97a%92%1C_%82jw%D6T%BAD%D4i%A3%83%9E%12%C2%A1x%17%14%14%0CKMM%5D%EA%EB%EB%1B%11%14%14%B4%40%A7%88%E3%C0%27%D8%0D%06%C3%F3%E2%E2%E2%FF%A6%A7%A7%3F%12%7Ce%A3%84%60%EAL%96%F7%14%D1T%0AHx%F1%12%FC%05%2Fa%DFC%A7%8Cc%E3%9Ft%AE%BAh%27%1F%3F%C1n%92%94%1E%C7%FF%05%18%00%ED-%01%F0O%3D%00%2B%00%00%00%00IEND%AEB%60%82');
+  float: right;
+  display: block;
+  height: 42px;
+  width: 150px;
+  position: relative;
+  text-indent: -2000px;
+  overflow: hidden;
+}
+</style>
+      <script type="text/javascript">
+      var datas = {
+        'data-list': Array('contact', 'webapi', 'cert', 'web-platform-tests'),
+        'type-list': Array('text', 'checkbox', 'checkbox', 'checkbox')
+      };
+
+      function UnknownMessage(msg) {
+        this.message = msg;
+      }
+
+      function InternalError(e) {
+        this.message = "Internal error: " + e;
+      }
+
+      function Client(addr) {
+        this.addr = addr;
+        this.ws = null;
+      }
+
+      Client.prototype = {
+         connect: function() {
+          this.ws = new WebSocket("ws://" + this.addr + "/tests");
+
+          this.ws.onopen = function(e) { console.log("open", e); }.bind(this);
+          this.ws.onclose = function(e) {
+            console.log("close", e);
+          }.bind(this);
+
+          this.ws.onmessage = function(e) {
+            var message = JSON.parse(e.data);
+            console.log("recv", message);
+
+            try {
+              this.parseMessage(message);
+            } catch (e) {
+              console.log("unkwn", message);
+              this.ws.close();
+              if (!(e instanceof UnknownMessage || e instanceof InternalError))
+                e = new InternalError(e);
+              console.log(e.message);
+            }
+          }.bind(this);
+        },
+
+        promptUser: function(text, image_path){
+          this.okEl = document.getElementById('ok');
+          this.cancelEl = document.getElementById('cancel');
+
+          this.okEl.onclick = function() {
+            message = this.value();
+            this.emit('prompt', message);
+            window.close(); }.bind(this);
+          this.cancelEl.onclick = function() { 
+            message = {'return':'cancel', 'result':'cancel'};
+            this.emit('prompt', JSON.stringify(message));
+            window.close();}.bind(this);
+        },
+
+        value: function() {
+          var result = {};
+          for (var i = datas['type-list'].length - 1; i >= 0; i--) {
+            var type = datas['type-list'][i];
+            var data = datas['data-list'][i];
+            if (type == 'text') {
+              result[data] = {};
+            };
+            if (type == 'checkbox') {
+              result[data] = Array();
+            };
+          }
+
+          for (var i = datas['type-list'].length - 1; i >= 0; i--) {
+            var type = datas['type-list'][i];
+            var data = datas['data-list'][i];
+              if (type == 'text') {
+                var x = document.getElementById(data);
+                var y = x.getElementsByTagName('input');
+                for (var j = y.length - 1; j >= 0; j--) {
+                  result[data][y[j].name] = y[j].value;
+                };
+              };
+              if (type == 'checkbox') {
+                var x = document.getElementById(data);
+                var y = x.getElementsByTagName('input');
+                for (var j = y.length - 1, k=0; j >= 0; j--) {
+                  if (!y[j].checked) {
+                    result[data][k++] = y[j].value;
+                  };
+                };
+              };
+          };
+          
+          return JSON.stringify({'return': 'ok', 'result': result});
+        },
+
+        parseMessage: function(data) {
+          var image_path = data.image || "";
+          console.log('action', data.action);
+          switch(data.action) {
+            case 'prompt':
+              this.promptUser(data.message, image_path);
+              break;
+
+            default:
+              throw new UnknownMessage(
+                "received unknown messag from server: " + data);
+          }
+        },
+
+        emit: function(event, data) {
+          var command = {};
+          command[event] = data || null;
+          var payload = JSON.stringify(command);
+          console.log("send", command);
+          this.ws.send(payload);
+        }
+      };
+
+      function App(server) {
+        this.addr = server;
+        this.client = new Client(this.addr);
+      }
+      App.prototype = {
+        start: function() {
+          this.client.connect();
+        }
+      };
+
+       //gApp = null;
+
+      const SERVER_ADDR = window.location.host;
+      function init() {
+        var app = new App(SERVER_ADDR);
+        app.start();
+        gApp = app;
+      }
+
+      document.addEventListener("DOMContentLoaded", init, false);
+      function log(x) {
+        console.log(x)
+      }
+
+      function getProfileString(datas) {
+        var result = {};
+        for (var i = datas['type-list'].length - 1; i >= 0; i--) {
+          var type = datas['type-list'][i];
+          var data = datas['data-list'][i];
+          if (type == 'text') {
+            result[data] = {};
+          };
+          if (type == 'checkbox') {
+            result[data] = Array();
+          };
+        }
+
+        for (var i = datas['type-list'].length - 1; i >= 0; i--) {
+          var type = datas['type-list'][i];
+          var data = datas['data-list'][i];
+            if (type == 'text') {
+              var x = document.getElementById(data);
+              var y = x.getElementsByTagName('input');
+              for (var j = y.length - 1; j >= 0; j--) {
+                result[data][y[j].name] = y[j].value;
+              };
+            };
+            if (type == 'checkbox') {
+              var x = document.getElementById(data);
+              var y = x.getElementsByTagName('input');
+              for (var j = y.length - 1, k=0; j >= 0; j--) {
+                if (!y[j].checked) {
+                  result[data][k++] = y[j].value;
+                };
+              };
+            };
+        };
+          
+        return JSON.stringify({'return': 'ok', 'result': result});
+       }
+    </script>
+  </head>
+
+  <body>
+    <a href="http://mozilla.org/" id="tabzilla">mozilla</a>
+
+      <div id='device' class='not-hidden'>
+        <div id='contact'>
+          <h1> Basic Information</h1>
+          <table>
+            <tr>
+          <td>email</td><td><input type='text' value='' id='email' name='email' maxlength=70 size=30></td> 
+            </tr>
+            <tr>
+          <td>company</td><td><input type='text' value='' id='company' name='company' maxlength=70 size=30></td> 
+            </tr>
+            <tr>
+          <td>device name</td><td><input type='text' value='' id='device' name='device' maxlength=70 size=30></td> 
+            </tr>
+            <tr>
+          <td>base gaia version</td><td><input type='text' value='' id='gaia' name='gaia' maxlength=70 size=30></td> 
+            </tr>
+            <tr>
+          <td>base gecko version</td><td><input type='text' value='' id='gecko' name='gecko' maxlength=70 size=30></td> 
+            </tr>
+          </table>
+        </div>
+
+        <div id='tests'>
+          <h1> Tests</h1>
+          <table>
+            <tr>
+              <td width=50%>
+          <div id='webapi'>
+            <h2>webapi</h2>
+          <table>
+            <tr>
+            <td><input name='apps' type='checkbox' value='apps' checked></td><td>apps</td>
+            </tr>
+            <tr>
+            <td><input name='bluetooth' type='checkbox' value='bluetooth' checked></td><td>bluetooth</td>
+            </tr>
+            <tr>
+            <td><input name='devicelight' type='checkbox' value='devicelight' checked></td><td>devicelight</td>
+            </tr>
+            <tr>
+            <td><input name='device_storage' type='checkbox' value='device_storage' checked></td><td>device_storage</td>
+            </tr>
+            <tr>
+            <td><input name='fm_radio' type='checkbox' value='fm_radio' checked></td><td>fm_radio</td>
+            </tr>
+            <tr>
+            <td><input name='geolocation' type='checkbox' value='geolocation' checked></td><td>geolocation</td>
+            </tr>
+            <tr>
+            <td><input name='idle' type='checkbox' value='idle' checked></td><td>idle</td>
+            </tr>
+            <tr>
+            <td><input name='mobile_message' type='checkbox' value='mobile_message' checked></td><td>mobile_message</td>
+            </tr>
+            <tr>
+            <td><input name='mozpower' type='checkbox' value='mozpower' checked></td><td>mozpower</td>
+            </tr>
+            <tr>
+            <td><input name='moztime' type='checkbox' value='moztime' checked></td><td>moztime</td>
+            </tr>
+            <tr>
+            <td><input name='notification' type='checkbox' value='notification' checked></td><td>notification</td>
+            </tr>
+            <tr>
+            <td><input name='orientation' type='checkbox' value='orientation' checked></td><td>orientation</td>
+            </tr>
+            <tr>
+            <td><input name='proximity' type='checkbox' value='proximity' checked></td><td>proximity</td>
+            </tr>
+            <tr>
+            <td><input name='tcp_socket' type='checkbox' value='tcp_socket' checked></td><td>tcp_socket</td>
+            </tr>
+            <tr>
+            <td><input name='telephony' type='checkbox' value='telephony' checked></td><td>telephony</td>
+            </tr>
+            <tr>
+            <td><input name='vibration' type='checkbox' value='vibration' checked></td><td>vibration</td>
+            </tr>
+            <tr>
+            <td><input name='wifi' type='checkbox' value='wifi' checked></td><td>wifi</td>
+            </tr>
+          </table>
+          </div>
+        </td>
+        <td width=50% valign='top'>
+          <div id='cert'>
+            <h2>cert</h2>
+          <table>
+            <tr>
+            <td><input name='omni-analyzer' type='checkbox' value='omni-analyzer' checked></td><td>omni-analyzer</td>
+            </tr>
+            <tr>
+            <td><input name='permissions' type='checkbox' value='permissions' checked></td><td>permissions</td>
+            </tr>
+            <tr>
+            <td><input name='webapi' type='checkbox' value='webapi' checked></td><td>webapi</td>
+            </tr>
+            <tr>
+            <td><input name='user-agent' type='checkbox' value='user-agent' checked></td><td>user-agent</td>
+            </tr>
+            <tr>
+            <td><input name='crash-reporter' type='checkbox' value='crash-reporter' checked></td><td>crash-reporter</td>
+            </tr>
+            <tr>
+            <td><input name='search-id' type='checkbox' value='search-id' checked></td><td>search-id</td>
+            </tr>
+          </table>
+          </div>
+          <div id='web-platform-tests'>
+            <h2>web-platform-tests</h2>
+          <table>
+            <tr>
+            <td><input name='IndexedDB' type='checkbox' value='IndexedDB' checked></td><td>IndexedDB</td>
+            </tr>
+            <tr>
+            <td><input name='dom' type='checkbox' value='dom' checked></td><td>dom</td>
+            </tr>
+            <tr>
+            <td><input name='touch-events' type='checkbox' value='touch-events' checked></td><td>touch-events</td>
+            </tr>
+          </table>
+          </div>
+        </td></tr></table>
+        </div>
+          <div class="controls">
+            <button id="ok">OK</button>
+            <button id="cancel">Cancel</button>
+          </div>
+      </div>
+  </body>
+</html>

--- a/webapi_tests/semiauto/testcase.py
+++ b/webapi_tests/semiauto/testcase.py
@@ -42,6 +42,11 @@ class TestCase(unittest.TestCase):
     def cleanup(self):
         if self.marionette is not None:
             certapp.kill(self.marionette, app=self.app)
+            
+    def check_skip(self, skiplist):
+        test_name = str(self.__class__).split('.')[1]
+        if test_name in skiplist:
+            self.skipTest('Skipped by device profile')
 
     def setUp(self):
         """Sets up the environment for a test case.
@@ -61,6 +66,10 @@ class TestCase(unittest.TestCase):
         super(TestCase, self).setUp()
 
         env = environment.get(InProcessTestEnvironment)
+
+        if env.device_profile:
+            self.check_skip(env.device_profile['webapi'])
+        
         self.server = env.server
         self.handler = env.handler
 


### PR DESCRIPTION
1. skip cert depends on device profile
2. add cert -p(--device-profile) command line parameter
3. setup_logging just pass log_f as parameter instead log_manager in harness.py
4. build command pass --device-profile parameter to cert and webapirunnter
5. Instruct test to input device profile
6. create persistent device profile if user specify the device profile file
7. add -d(--debug) parameter to not uninstall marionette server in device
8. add -c for --config
9. add -l for --list-tests
10. remove else after list-tests
11. add the device_profile link and content to the summary report
12. unlink the temporary device profile file
13. load device profile file and store to env global variable in webapi testing
14. add webapi_tests/semiauto/static/profile.html for device profile UI
15. check device profile in global env if need to skip test in webapi test