### PR TITLE
Bug 1149013 - [MCTS][2.2] device_profile in report_manager not found

### DIFF
--- a/certsuite/harness.py
+++ b/certsuite/harness.py
@@ -413,7 +413,7 @@ def edit_device_profile(device_profile_path):
 def check_device_profile(device_profile_path):
     try:
         with open(device_profile_path, 'r') as device_profile_file:
-            device_profile_object = json.loads(device_profile_file)
+            device_profile_object = json.load(device_profile_file)
             if not 'result' in device_profile_object:
                 logger.error('Invalide device profile file [%s]' % device_profile_path)
             else:

--- a/certsuite/report/summary.py
+++ b/certsuite/report/summary.py
@@ -67,7 +67,7 @@ class HTMLBuilder(object):
                 with open(log_path, 'r') as f:
                     details_log = f.read()
                 href = 'data:text/plain;charset=utf-8;base64,%s' % base64.b64encode(details_log)
-                ul.append(html.a(html.a(log__path, href=href, target='_blank')))
+                ulbody.append(html.a(html.a(log_path, href=href, target='_blank')))
             body_parts.append(html.ul(ulbody))
         return html.body(body_parts)
 

--- a/certsuite/reportmanager.py
+++ b/certsuite/reportmanager.py
@@ -59,6 +59,6 @@ class ReportManager(object):
         html_str = report.summary.make_report(self.time,
                                               summary_results,
                                               self.subsuite_results,
-                                              [path, self.device_profile])
+                                              [path, self.device_profile_path])
         path = "report.html"
         self.zip_file.writestr(path, html_str)


### PR DESCRIPTION
1. fix device_profile not found in report_manager: use device_profile_path
2. json loads should be load
3. ul object should be ulbody