### PR TITLE
Bug 1153728 - [MCTS] Change omni.ja test with a HTML output format in report

### DIFF
--- a/certsuite/cert.py
+++ b/certsuite/cert.py
@@ -509,7 +509,10 @@ def _run(args, logger):
         omni_ref_path = pkg_resources.resource_filename(
                             __name__, os.path.join('expected_omni_results', 'omni.ja.%s' % args.version))
         omni_analyzer = OmniAnalyzer(omni_ref_path, logger=logger)
-        diff, is_run_success = omni_analyzer.run()
+        if args.html_result_file is not None:
+            diff, is_run_success = omni_analyzer.run(html_format=True, results_file=os.path.join(os.path.dirname(args.html_result_file), 'omni_diff_report.html'))
+        else:
+            diff, is_run_success = omni_analyzer.run()
         report["omni_result"] = diff
         if is_run_success:
             logger.test_end('omni-analyzer', 'OK')

--- a/certsuite/config.json
+++ b/certsuite/config.json
@@ -8,7 +8,8 @@
                                    "--html-result-file=%(temp_dir)s/cert_results.html"
 ],
                       "extra_files": ["%(temp_dir)s/cert_results.json",
-                                      "%(temp_dir)s/cert_results.html"]}],
+                                      "%(temp_dir)s/cert_results.html",
+                                      "%(temp_dir)s/omni_diff_report.html"]}],
             ["web-platform-tests", {"cmd": "wptrunner",
                                     "common_args": ["--include-manifest=web-platform-tests/include.ini", "--config=web-platform-tests/wptrunner.ini"],
                                     "run_args": ["--product=b2g", "--test-type=testharness", "--b2g-no-backup"]}]

--- a/certsuite/report/summary.py
+++ b/certsuite/report/summary.py
@@ -132,7 +132,6 @@ class HTMLBuilder(object):
         rv = []
         for key in results.keys():
             result = results[key]['results']
-            details_link = 'data:text/html;charset=utf-8;base64,%s' % base64.b64encode(results[key]['html_str'])
             cells = [html.td(key, class_="col-subsuite")]
             if result.has_errors:
                 cells.append(html.td(
@@ -148,6 +147,7 @@ class HTMLBuilder(object):
             else:
                 cells.append(html.td("0", class_="condition PASS"))
             
+            details_link = 'data:text/html;charset=utf-8;base64,%s' % base64.b64encode(results[key]['html_str'])
             ulbody = [html.li(html.a("subsuite report", href=details_link, target='_blank'))]
             files = results[key]['files']
             for fname in files.keys():

--- a/certsuite/reportmanager.py
+++ b/certsuite/reportmanager.py
@@ -36,11 +36,11 @@ class ReportManager(object):
         # prepare embeded file data
         files_map = {}
         for path in result_files:
-            file_name = os.path.split(path)[1]
-            with open(path, 'r') as f:
-                files_map[file_name] = f.read()
-            self.zip_file.writestr("%s/%s" % (results.name, os.path.basename(path)),
-                                   files_map[file_name])
+            if os.path.exists(path):
+                file_name = os.path.split(path)[1]
+                with open(path, 'r') as f:
+                    files_map[file_name] = f.read()
+                self.zip_file.writestr("%s/%s" % (results.name, os.path.basename(path)), files_map[file_name])
         results.set('files', files_map)
 
         self.subsuite_results[results.name] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sphinx
 tornado >= 3.2
 wptrunner == 1.4
 wptserve >= 1.0.1
+diff_py >= 0.0.11


### PR DESCRIPTION
- add 'omni_diff_report.html' for differ.
- remove base64 encoding string from subsuite report.