### PR TITLE
Bug 1159606 - [MCTS] summary report display regressions in red is strang...

### DIFF
--- a/certsuite/report/results.py
+++ b/certsuite/report/results.py
@@ -21,7 +21,6 @@ def is_regression(data):
 
     return result_status[data["status"]] > result_status[data["expected"]]
 
-
 class LogHandler(reader.LogHandler):
     def __init__(self):
         self.results = Results()
@@ -38,10 +37,16 @@ class LogHandler(reader.LogHandler):
     def test_status(self, data):
         test_id = self.test_id(data)
 
+        if data["status"] == 'FAIL':
+            self.results.fails = self.results.fails + 1
+
         self.results.regressions[test_id][data["subtest"]] = data
 
     def test_end(self, data):
         test_id = self.test_id(data)
+
+        if data["status"] == 'FAIL':
+            self.results.fails = self.results.fails + 1
 
         self.results.regressions[test_id][KEY_MAIN] = data
 
@@ -55,6 +60,7 @@ class Results(object):
         self.regressions = defaultdict(dict)
         self.errors = []
         self.map = {}
+        self.fails = 0
 
     @property
     def is_pass(self):
@@ -63,6 +69,10 @@ class Results(object):
     @property
     def has_regressions(self):
         return len(self.regressions) > 0
+
+    @property
+    def has_fails(self):
+        return self.fails > 0
 
     @property
     def has_errors(self):

--- a/certsuite/report/summary.py
+++ b/certsuite/report/summary.py
@@ -118,7 +118,7 @@ class HTMLBuilder(object):
                 html.tr(
                     html.th("Subsuite", class_='sortable', col='subsuite'),
                     html.th("Subsuite Errors"),
-                    html.th("Test Regressions"),
+                    html.th("Test Executions"),
                     html.th("Details")
                 )
             ),
@@ -141,9 +141,12 @@ class HTMLBuilder(object):
             else:
                 cells.append(html.td("0",
                                      class_="condition PASS"))
+            style = ''
+            if result.has_fails or result.has_errors:
+                style = 'background-color: darkblue;'
             if result.has_regressions:
                 num_regressions = sum(len(item) for item in result.regressions.itervalues())
-                cells.append(html.td(num_regressions, class_="condition FAIL"))
+                cells.append(html.td(num_regressions, class_="condition PASS", style=style))
             else:
                 cells.append(html.td("0", class_="condition PASS"))
             


### PR DESCRIPTION
...e

1. change Test Regresions to 'Test Executions'
2. change 'Test Executions' cell color to 'darkblue' when there is errors or fails
   if no fails and no errors, it just does not change the color