### PR TITLE
Bug 1162834 - [MCTS] support windows platform running MCTS

### DIFF
--- a/certsuite/harness.py
+++ b/certsuite/harness.py
@@ -69,6 +69,11 @@ def setup_logging(log_f):
 def load_config(path):
     with open(path) as f:
         config = json.load(f)
+
+    if sys.platform == 'win32':
+        config_str = json.dumps(config)
+        config_str.replace('/', os.sep)
+        config = json.loads(config_str)
     config["suites"] = OrderedDict(config["suites"])
     return config
 
@@ -271,7 +276,7 @@ class TestRunner(object):
         cmd = [suite_opts['cmd']]
 
         subtests = '' if groups == [] else '_' + "_".join(item.replace("/", "-") for item in groups)
-        log_name = "%s/%s_structured%s.log" % (temp_dir, suite, subtests)
+        log_name = os.sep.join([temp_dir,"%s_structured%s.log" % (suite, subtests)])
         cmd.extend(["--log-raw=-"])
 
         if groups:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fxos-appgen >= 0.13
 gaiatest == 0.26
 marionette_client == 0.7.10
 marionette_extension >= 0.4.8
-mozdevice >= 0.41
+mozdevice >= 0.45
 mozlog >= 2.1
 moznetwork >= 0.24
 mozprocess >= 0.18


### PR DESCRIPTION
1. change mozdevice to 0.45
2. update load config in windows platform
3. update log name in windows platform