### PR TITLE
Bug 1175008 - [MCTS][v2.2] missing attribute restore while running MCTS 

### DIFF
--- a/mcts/harness.py
+++ b/mcts/harness.py
@@ -366,6 +366,9 @@ class NoADBDeviceBackup():
         return self
     def __exit__(self, *args, **kwargs):
         pass
+    def restore(self):
+        pass
+
 
 class NoADB():
     def reboot(self):


### PR DESCRIPTION
add restore method in NoADBDeviceBackup obj
@oouyang r?